### PR TITLE
add helper for retrieving the kube config itself

### DIFF
--- a/kubeutils/kube_cfg.go
+++ b/kubeutils/kube_cfg.go
@@ -33,3 +33,12 @@ func GetConfig(masterURL, kubeconfigPath string) (*rest.Config, error) {
 
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides).ClientConfig()
 }
+
+// GetConfig gets the kubernetes client config
+func GetKubeConfig(masterURL, kubeconfigPath string) (*clientcmdapi.Config, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	loadingRules.ExplicitPath = kubeconfigPath
+	configOverrides := &clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: masterURL}}
+
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides).ConfigAccess().GetStartingConfig()
+}


### PR DESCRIPTION
this is being used currently in an upcoming PR for `glooctl` which wants to read the default kube namespace from the kubeconfig (so the user doesn't have to manuall provide it)