### PR TITLE
Upload release asset cli

### DIFF
--- a/changelog/v0.2.10/release-asset-cli.yaml
+++ b/changelog/v0.2.10/release-asset-cli.yaml
@@ -2,3 +2,6 @@ changelog:
   - type: NEW_FEATURE
     description: A utility CLI has been added for uploading release artifacts to github, to replace the old shell script. See the [readme](https://github.com/solo-io/go-utils/tree/master/githubutils) for more information.
     issueLink: https://github.com/solo-io/go-utils/issues/38
+  - type: FIX
+    description: PushDocsCli no longer errors on the initial push when the destination directory doesn't exist.
+    issueLink: https://github.com/solo-io/go-utils/issues/40

--- a/changelog/v0.2.10/release-asset-cli.yaml
+++ b/changelog/v0.2.10/release-asset-cli.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NEW_FEATURE
+    description: A utility CLI has been added for uploading release artifacts to github, to replace the old shell script. See the [readme](https://github.com/solo-io/go-utils/tree/master/githubutils) for more information.
+    issueLink: https://github.com/solo-io/go-utils/issues/38

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -29,4 +29,4 @@ secrets:
     secretEnv:
       GITHUB_TOKEN: CiQABlzmSYYiveU0gTxGH2139eaBUedjV3vNCxQmJU+nRPlfQ/YSUQCCPGSGzbGp49fwDYuefAx9V94b8mivdp9AqB7zQAa07VtGJmrGdg9ZuhKGFrrgqxwABE0LLVNHyngCSHYSYMH8Vn/mRtT7wQuEHBlKVGtqPw==
 
-timeout: 6600s
+timeout: 1200s

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -28,3 +28,5 @@ secrets:
   - kmsKeyName: projects/solo-public/locations/global/keyRings/build/cryptoKeys/build-key
     secretEnv:
       GITHUB_TOKEN: CiQABlzmSYYiveU0gTxGH2139eaBUedjV3vNCxQmJU+nRPlfQ/YSUQCCPGSGzbGp49fwDYuefAx9V94b8mivdp9AqB7zQAa07VtGJmrGdg9ZuhKGFrrgqxwABE0LLVNHyngCSHYSYMH8Vn/mRtT7wQuEHBlKVGtqPw==
+
+timeout: 6600s

--- a/docsutils/cli.go
+++ b/docsutils/cli.go
@@ -376,6 +376,11 @@ func replaceApiDirectories(product, docsParentPath string, paths ...string) erro
 			if err != nil {
 				return err
 			}
+		} else {
+			err = fs.MkdirAll(soloDocsPath, 0700)
+			if err != nil {
+				return err
+			}
 		}
 		err = copyRecursive(docsPath, soloDocsPath)
 		if err != nil {

--- a/docsutils/cli.go
+++ b/docsutils/cli.go
@@ -44,18 +44,9 @@ type DocsPRSpec struct {
 }
 
 func PushDocsCli(spec *DocsPRSpec) {
-	tag, present := os.LookupEnv("TAGGED_VERSION")
-	if !present || tag == "" {
-		fmt.Printf("TAGGED_VERSION not found in environment, skipping docs PR.\n", tag)
-		os.Exit(0)
-	}
-	_, err := versionutils.ParseVersion(tag)
-	if err != nil {
-		fmt.Printf("TAGGED_VERSION %s is not a valid semver version, skipping docs PR.\n", tag)
-		os.Exit(0)
-	}
-	spec.Tag = tag
-	err = CreateDocsPRFromSpec(spec)
+	version := versionutils.GetReleaseVersionOrExitGracefully()
+	spec.Tag = version.String()
+	err := CreateDocsPRFromSpec(spec)
 	if err != nil {
 		log.Fatalf(err.Error())
 	}

--- a/githubutils/README.md
+++ b/githubutils/README.md
@@ -1,0 +1,65 @@
+## Uploading Release Assets to Github
+
+To upload release assets to Github, follow these steps (requires go-utils 0.2.10+). 
+
+### Create a Go script
+
+Create a script `upload_github_release_asset.go`, like this: 
+
+```go
+package main
+
+import (
+	"github.com/solo-io/go-utils/githubutils"
+)
+
+func main() {
+	assets := make([]githubutils.ReleaseAssetSpec, 2)
+	assets[0] = githubutils.ReleaseAssetSpec{
+		Name: "hello",
+		ParentPath: "_output",
+		UploadSHA: true,
+	}
+	assets[1] = githubutils.ReleaseAssetSpec{
+		Name: "my-resource.yaml",
+		ParentPath: "namespace",
+	}
+	spec := githubutils.UploadReleaseAssetSpec{
+		Owner: "solo-io",
+		Repo: "testrepo",
+		Assets: assets,
+		SkipAlreadyExists: true,
+	}
+	githubutils.UploadReleaseAssetCli(&spec)
+}
+```
+
+### Create a Make target
+
+```bash
+#----------------------------------------------------------------------------------
+# Github Assets
+#----------------------------------------------------------------------------------
+
+.PHONY: upload-github-release-assets
+upload-github-release-assets: hello
+	go run upload_github_release_assets.go
+```
+
+### Update cloudbuild.yaml to call this target
+
+```yaml
+steps:
+- name: 'gcr.io/solo-corp/go-mod-make:0.1.1'
+  args: [..., 'upload-github-release-assets', ...]
+  secretEnv: ['GITHUB_TOKEN']
+  env:
+  - 'TAGGED_VERSION=$TAG_NAME'
+```
+
+Make sure `GITHUB_TOKEN` and `TAGGED_VERSION` are in the environment. 
+
+### Notes
+
+* On each asset, a flag `UploadSHA` can be set to true to upload a SHA256 hash file. 
+* Set `SkipAlreadyExists=true` to not fail when trying to upload an asset that already exists. 

--- a/githubutils/upload_release_asset.go
+++ b/githubutils/upload_release_asset.go
@@ -1,0 +1,52 @@
+package githubutils
+
+import (
+	"context"
+	"github.com/google/go-github/github"
+	"github.com/solo-io/go-utils/versionutils"
+	"log"
+	"os"
+)
+
+type UploadReleaseAssetSpec struct {
+	Owner  string
+	Repo   string
+	Assets map[string]*os.File
+}
+
+func UploadReleaseAssetCli(spec *UploadReleaseAssetSpec) {
+	version := versionutils.GetReleaseVersionOrExitGracefully()
+	ctx := context.TODO()
+	client := GetClientOrExit(ctx)
+	release := GetReleaseOrExit(ctx, client, version, spec)
+	UploadReleaseAssetsOrExit(ctx, client, release, spec)
+}
+
+func UploadReleaseAssetsOrExit(ctx context.Context, client *github.Client, release *github.RepositoryRelease, spec *UploadReleaseAssetSpec) {
+	for name, asset := range spec.Assets {
+		opts := &github.UploadOptions{
+			Name: name,
+		}
+		_, _, err := client.Repositories.UploadReleaseAsset(ctx, spec.Owner, spec.Repo, release.GetID(), opts, asset)
+		if err != nil {
+			log.Fatalf("Error uploading assets. Error was: %s", err.Error())
+		}
+	}
+
+}
+
+func GetClientOrExit(ctx context.Context) *github.Client {
+	client, err := GetClient(ctx)
+	if err != nil {
+		log.Fatalf("Could not get github client. Error was: %s", err.Error())
+	}
+	return client
+}
+
+func GetReleaseOrExit(ctx context.Context, client *github.Client, version *versionutils.Version, spec *UploadReleaseAssetSpec) *github.RepositoryRelease {
+	release, _, err := client.Repositories.GetReleaseByTag(ctx, spec.Owner, spec.Repo, version.String())
+	if err != nil {
+		log.Fatalf("Could not find release %s. Error was: %s", version.String(), err.Error())
+	}
+	return release
+}

--- a/versionutils/cli.go
+++ b/versionutils/cli.go
@@ -1,0 +1,20 @@
+package versionutils
+
+import (
+	"fmt"
+	"os"
+)
+
+func GetReleaseVersionOrExitGracefully() *Version {
+	tag, present := os.LookupEnv("TAGGED_VERSION")
+	if !present || tag == "" {
+		fmt.Printf("TAGGED_VERSION not found in environment, skipping docs PR.\n", tag)
+		os.Exit(0)
+	}
+	version, err := ParseVersion(tag)
+	if err != nil {
+		fmt.Printf("TAGGED_VERSION %s is not a valid semver version, skipping docs PR.\n", tag)
+		os.Exit(0)
+	}
+	return version
+}

--- a/versionutils/cli.go
+++ b/versionutils/cli.go
@@ -8,7 +8,7 @@ import (
 func GetReleaseVersionOrExitGracefully() *Version {
 	tag, present := os.LookupEnv("TAGGED_VERSION")
 	if !present || tag == "" {
-		fmt.Printf("TAGGED_VERSION not found in environment, skipping docs PR.\n", tag)
+		fmt.Printf("TAGGED_VERSION not found in environment, skipping docs PR.\n")
 		os.Exit(0)
 	}
 	version, err := ParseVersion(tag)


### PR DESCRIPTION
Migrating repositories to `UploadReleaseAssetCli`, distributed in `go-utils/githubutils/cli.go`. 

Convention changes:
* With the `SkipAlreadyExists: true` flag, this script will not error if some / all of the artifacts were already uploaded (does simplistic checking on name only). This enables re-running release builds without needing to clear state, when a release build fails. 
* Use this CLI instead of shell script. Script will be removed from repos. 
* Move away from `release` target, create `upload-github-release-assets` make target instead. 
* Target is always run, logic to determine if this is a release is in the CLI. Make target should be: 
```.PHONY: upload-github-release-assets
upload-github-release-assets:
	go run upload_github_release_assets.go
```

This assumes the release artifacts have already been built. To enforce this, you could add the related make targets as a dependency here, though then we're duplicating the dependencies of targets. 