### PR TITLE
Added pkgmgmtutils.FormulaOptions.FormulaName field

### DIFF
--- a/changelog/v0.7.9/package-manager-update.yaml
+++ b/changelog/v0.7.9/package-manager-update.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: FIX
+    description: >
+      Added a FormulaOptions.FormulaName field to allow the FormulaOptions.Name field to be a descriptive name, and
+      FormulaOptions.FormulaName to be used to reference the proper formula name as needed in branch and commit name
+      conventions for external PRs.
+    issueLink: https://github.com/solo-io/go-utils/issues/128

--- a/pkgmgmtutils/update_formula_test.go
+++ b/pkgmgmtutils/update_formula_test.go
@@ -6,29 +6,31 @@ import (
 )
 
 var _ = Describe("package management utils", func() {
-	/* Keeping this example code till we integrate into individual projects like solo-io/gloo
-	It("can get latest release version", func() {
+	// Keeping this example code till we integrate into individual projects like solo-io/gloo
+	/*	It("can get latest release version", func() {
 
 		fopts := []FormulaOptions{
 			{
-				Name:            "glooctl",
-				Path:            "Formula/glooctl.rb",
-				RepoOwner:       "scranton",     // Make change in this repo
-				RepoName:        "homebrew-tap", // assumes this repo is forked from PRRepo
-				PRRepoOwner:     "solo-io",      // Make PR to this repo
-				PRRepoName:      "homebrew-tap",
-				PRBranch:        "solo-io",
-				PRDescription:   "",
-				PRCommitName:    "Solo-io Bot",
-				PRCommitEmail:   "bot@solo.io",
-				VersionRegex:    `version\s*"([0-9.]+)"`,
-				DarwinShaRegex:  `url\s*".*-darwin.*\W*sha256\s*"(.*)"`,
-				LinuxShaRegex:   `url\s*".*-linux.*\W*sha256\s*"(.*)"`,
+				Name:           "homebrew-tap/glooctl",
+				FormulaName:    "glooctl",
+				Path:           "Formula/glooctl.rb",
+				RepoOwner:      "solo-io",      // Make change in this repo
+				RepoName:       "homebrew-tap", // assumes this repo is forked from PRRepo
+				PRRepoOwner:    "solo-io",      // Make PR to this repo
+				PRRepoName:     "homebrew-tap",
+				PRBranch:       "solo-io",
+				PRDescription:  "",
+				PRCommitName:   "Solo-io Bot",
+				PRCommitEmail:  "bot@solo.io",
+				VersionRegex:   `version\s*"([0-9.]+)"`,
+				DarwinShaRegex: `url\s*".*-darwin.*\W*sha256\s*"(.*)"`,
+				LinuxShaRegex:  `url\s*".*-linux.*\W*sha256\s*"(.*)"`,
 
 				dryRun: true, // do NOT create a PR
 			},
 			{
-				Name:            "glooctl",
+				Name:            "fish-food/glooctl",
+				FormulaName:     "glooctl",
 				Path:            "Food/glooctl.lua",
 				RepoOwner:       "solo-io",
 				RepoName:        "fish-food",
@@ -46,7 +48,8 @@ var _ = Describe("package management utils", func() {
 				dryRun: true, // do NOT create a PR
 			},
 			{
-				Name:            "glooctl",
+				Name:            "homebrew-core/glooctl",
+				FormulaName:     "glooctl",
 				Path:            "Formula/glooctl.rb",
 				RepoOwner:       "solo-io",
 				RepoName:        "homebrew-core",

--- a/pkgmgmtutils/update_formulas.go
+++ b/pkgmgmtutils/update_formulas.go
@@ -23,7 +23,8 @@ import (
 const PRBaseBranchDefault = "master"
 
 type FormulaOptions struct {
-	Name            string
+	Name            string // Descriptive name to be used for logging and general identification
+	FormulaName     string // proper formula name without file extension
 	Path            string // repo relative path with file extension
 	RepoOwner       string // repo owner for Formula change
 	RepoName        string // repo name for Formula change
@@ -78,8 +79,8 @@ func UpdateFormulas(projectRepoOwner string, projectRepoName string, parentPathS
 		status[i].Name = fOpt.Name
 		status[i].Updated = false
 
-		branchName := fOpt.Name + "-" + version
-		commitString := fOpt.Name + ": update " + version
+		branchName := fOpt.FormulaName + "-" + version
+		commitString := fOpt.FormulaName + ": update " + version
 
 		if fOpt.PRRepoName == fOpt.RepoName && fOpt.PRRepoOwner == fOpt.RepoOwner {
 			err = updateAndPushAllRemote(client, ctx, version, versionSha, branchName, commitString, shas, &fOpt)


### PR DESCRIPTION
Allows FormulaOptions.Name to be a descriptive name for logging, and
FormulaOptions.FormulaName used for proper formula name as needed for
branch and commit naming conventions required for external PRs.
BOT NOTES: 
resolves https://github.com/solo-io/go-utils/issues/128