### PR TITLE
Kube dump fail handler

### DIFF
--- a/botutils/botconfig/botconfig_suite_test.go
+++ b/botutils/botconfig/botconfig_suite_test.go
@@ -12,10 +12,7 @@ import (
 func TestBotconfig(t *testing.T) {
 	test = t
 	RegisterFailHandler(Fail)
-	testutils.RegisterPreFailHandler(
-		func() {
-			testutils.PrintTrimmedStack()
-		})
+	testutils.RegisterPreFailHandler(testutils.PrintTrimmedStack)
 	testutils.RegisterCommonFailHandlers()
 	RunSpecs(t, "Botconfig Suite")
 }

--- a/changelog/v0.9.18/print-kube-dump.yaml
+++ b/changelog/v0.9.18/print-kube-dump.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Add print kube dump pre fail handler

--- a/changelogutils/changelogutils_suite_test.go
+++ b/changelogutils/changelogutils_suite_test.go
@@ -12,10 +12,7 @@ import (
 func TestChangelogUtils(t *testing.T) {
 	test = t
 	RegisterFailHandler(Fail)
-	testutils.RegisterPreFailHandler(
-		func() {
-			testutils.PrintTrimmedStack()
-		})
+	testutils.RegisterPreFailHandler(testutils.PrintTrimmedStack)
 	testutils.RegisterCommonFailHandlers()
 	RunSpecs(t, "ChangelogUtils Suite")
 }

--- a/clicore/clicore_suite_test.go
+++ b/clicore/clicore_suite_test.go
@@ -10,10 +10,7 @@ import (
 
 func TestCliCore(t *testing.T) {
 
-	testutils.RegisterPreFailHandler(
-		func() {
-			testutils.PrintTrimmedStack()
-		})
+	testutils.RegisterPreFailHandler(testutils.PrintTrimmedStack)
 	testutils.RegisterCommonFailHandlers()
 	RegisterFailHandler(Fail)
 	testutils.SetupLog()

--- a/testutils/README.md
+++ b/testutils/README.md
@@ -5,18 +5,13 @@
 
 The `PrintTrimmedStack` fail handler simplifies error tracking in ginkgo tests by printing a condensed stack trace upon failure. Printout excludes well-known overhead files so you can more easily sight the failing line. This eliminates the need to count stack offset via `ExpectWithOffset`. You can just use `Expect`.
 
-
 ### Usage
 
 To use, register `PrintTrimmedStack` as a prefail handler with `RegisterPreFailHandler` in your `ginkgo` suite:
 
 ```go
 func TestCliCore(t *testing.T) {
-
-	testutils.RegisterPreFailHandler(
-		func() {
-			testutils.PrintTrimmedStack()
-		})
+	testutils.RegisterPreFailHandler(testutils.PrintTrimmedStack)
 	testutils.RegisterCommonFailHandlers()
 	RegisterFailHandler(Fail)
 	testutils.SetupLog()

--- a/testutils/goimpl/goimpl_suite_test.go
+++ b/testutils/goimpl/goimpl_suite_test.go
@@ -10,10 +10,7 @@ import (
 
 func TestGoImpl(t *testing.T) {
 
-	testutils.RegisterPreFailHandler(
-		func() {
-			testutils.PrintTrimmedStack()
-		})
+	testutils.RegisterPreFailHandler(testutils.PrintTrimmedStack)
 	testutils.RegisterCommonFailHandlers()
 	RunSpecs(t, "Go Impl Suite")
 }

--- a/testutils/kube/kube_dump.go
+++ b/testutils/kube/kube_dump.go
@@ -1,0 +1,66 @@
+package kube
+
+import (
+	"fmt"
+	"github.com/solo-io/go-utils/testutils"
+	"github.com/solo-io/go-utils/testutils/helper"
+	"strconv"
+	"strings"
+)
+
+const maxLogLines = 250
+
+// The PrintKubeDump fail handler eases debugging failed regression/e2e tests by dumping all
+// kube pod logs and statuses in the install namespace
+func PrintKubeDump(testHelper *helper.SoloTestHelper) {
+	var logs strings.Builder
+	podsList, err := testutils.KubectlOut("get", "pods", "--no-headers", "-n", testHelper.InstallNamespace,
+		"-o", "custom-columns=:metadata.name")
+	if err != nil {
+		fmt.Println("PrintKubeDump - error getting pods: ", err.Error())
+		return
+	}
+	unfilteredPods := strings.Split(podsList, "\n")
+	pods := make([]string, 0, len(unfilteredPods))
+	for _, pod := range unfilteredPods {
+		if pod != "" {
+			pods = append(pods, pod)
+		}
+	}
+
+	for _, pod := range pods {
+		podStatus, err := testutils.KubectlOut("get", "pods", pod, "-n", testHelper.InstallNamespace,
+			"-o", "go-template=\"{{range .status.containerStatuses}}{{.state}}{{end}}\"")
+		if err != nil {
+			logs.WriteString("unable to get state for pod: " + pod + "\n")
+		} else {
+			logs.WriteString("state for pod: " + pod + ": " + podStatus + "\n")
+		}
+
+		podLogs, err := testutils.KubectlOut("logs", pod, "-n", testHelper.InstallNamespace,
+			"--all-containers", "--tail", strconv.Itoa(maxLogLines))
+		if err != nil {
+			logs.WriteString("error getting logs for " + pod + ": " + err.Error() + "\n")
+
+			prevPodLogs, err := testutils.KubectlOut("logs", pod, "-n", testHelper.InstallNamespace,
+				"--all-containers", "--tail", strconv.Itoa(maxLogLines), "-p")
+			if err != nil {
+				logs.WriteString("error getting previous logs for " + pod + ": " + err.Error() + "\n\n")
+				continue
+			}
+			logs.WriteString("--- previous logs for " + pod + " ---\n")
+			logs.WriteString(prevPodLogs)
+			logs.WriteString("--- end previous logs for " + pod + " ---\n\n")
+			continue
+		}
+		logs.WriteString("--- logs for " + pod + " ---\n")
+		logs.WriteString(podLogs)
+		logs.WriteString("--- end logs for " + pod + " ---\n\n")
+	}
+	if len(pods) > 0 {
+		fmt.Printf("\n********** Kube Dump **********\n\n" + logs.String() +
+			"\n******** End Kube Dump ********\n\n")
+	} else {
+		fmt.Println("PrintKubeDump - No pods found, thus no logs to print")
+	}
+}

--- a/testutils/trimmed_stack_fail_handler.go
+++ b/testutils/trimmed_stack_fail_handler.go
@@ -9,7 +9,7 @@ import (
 	"runtime/debug"
 )
 
-//PrintTrimmedStack helps you find the line of the failing assertion without producing excessive noise.
+// PrintTrimmedStack helps you find the line of the failing assertion without producing excessive noise.
 // This is achieved by printing a stack trace and pruning lines associated with known overhead.
 // With this fail handler, you do not need to count stack offsets ExpectWithOffset(x, ...) and can just Expect(...)
 func PrintTrimmedStack() {

--- a/versionutils/versionutils_suite_test.go
+++ b/versionutils/versionutils_suite_test.go
@@ -11,10 +11,7 @@ import (
 
 func TestVersionUtils(t *testing.T) {
 	RegisterFailHandler(Fail)
-	testutils.RegisterPreFailHandler(
-		func() {
-			testutils.PrintTrimmedStack()
-		})
+	testutils.RegisterPreFailHandler(testutils.PrintTrimmedStack)
 	testutils.RegisterCommonFailHandlers()
 	RunSpecs(t, "Versionutils Suite")
 }


### PR DESCRIPTION
related to: https://github.com/solo-io/gloo/issues/985

## Goal
Print kube pod logs and statuses in kube install namespace to ease debugging failed regression/e2e tests in CI

## Context
tested in gloo-ee PR and used to debug a failing regression test (printed the kube pod status with the failed image it was trying to pull, which was malformed)