### PR TITLE
Get dependency version from revision/branch fields

### DIFF
--- a/changelog/v0.10.7/improve-toml-parsing.yaml
+++ b/changelog/v0.10.7/improve-toml-parsing.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NEW_FEATURE
+  issueLink: https://github.com/solo-io/go-utils/issues/291
+  description: Consider all possible version fields (version, branch, revision) when retrieving a dependency version from a .toml file.

--- a/versionutils/repo.go
+++ b/versionutils/repo.go
@@ -164,7 +164,7 @@ func getVersionFromTree(tomlTree *toml.Tree, pkgName string) (version string, fo
 	}
 
 	if tomlTree.Get(nameConst) != pkgName {
-		return
+		return "", false
 	}
 
 	switch {
@@ -175,5 +175,5 @@ func getVersionFromTree(tomlTree *toml.Tree, pkgName string) (version string, fo
 	case !isEmpty(tomlTree, branchConst):
 		return tomlTree.Get(branchConst).(string), true
 	}
-	return
+	return "", false
 }

--- a/versionutils/repo.go
+++ b/versionutils/repo.go
@@ -163,12 +163,16 @@ func getVersionFromTree(tomlTree *toml.Tree, pkgName string) (version string, fo
 		return node.Get(key) == nil || node.Get(key) == ""
 	}
 
+	if tomlTree.Get(nameConst) != pkgName {
+		return
+	}
+
 	switch {
-	case tomlTree.Get(nameConst) == pkgName && !isEmpty(tomlTree, versionConst):
+	case !isEmpty(tomlTree, versionConst):
 		return tomlTree.Get(versionConst).(string), true
-	case tomlTree.Get(nameConst) == pkgName && !isEmpty(tomlTree, revisionConst):
+	case !isEmpty(tomlTree, revisionConst):
 		return tomlTree.Get(revisionConst).(string), true
-	case tomlTree.Get(nameConst) == pkgName && !isEmpty(tomlTree, branchConst):
+	case !isEmpty(tomlTree, branchConst):
 		return tomlTree.Get(branchConst).(string), true
 	}
 	return

--- a/versionutils/repo.go
+++ b/versionutils/repo.go
@@ -77,7 +77,7 @@ func GetVersionFromTag(shouldBeAVersion string) (string, error) {
 // Deprecated: Use GetTomlVersion instead
 func GetVersion(pkgName string, tomlTree []*toml.Tree) (string, error) {
 	for _, v := range tomlTree {
-		if found, version := getVersionFromTree(v, pkgName); found {
+		if version, found := getVersionFromTree(v, pkgName); found {
 			return version, nil
 		}
 	}
@@ -86,12 +86,12 @@ func GetVersion(pkgName string, tomlTree []*toml.Tree) (string, error) {
 
 func GetTomlVersion(pkgName string, toml *TomlWrapper) (string, error) {
 	for _, v := range toml.Overrides {
-		if found, version := getVersionFromTree(v, pkgName); found {
+		if version, found := getVersionFromTree(v, pkgName); found {
 			return version, nil
 		}
 	}
 	for _, v := range toml.Constraints {
-		if found, version := getVersionFromTree(v, pkgName); found {
+		if version, found := getVersionFromTree(v, pkgName); found {
 			return version, nil
 		}
 	}
@@ -158,18 +158,18 @@ func ParseFullToml() (*TomlWrapper, error) {
 	return ParseFullTomlFromDir("")
 }
 
-func getVersionFromTree(tomlTree *toml.Tree, pkgName string) (found bool, version string) {
+func getVersionFromTree(tomlTree *toml.Tree, pkgName string) (version string, found bool) {
 	isEmpty := func(node *toml.Tree, key string) bool {
 		return node.Get(key) == nil || node.Get(key) == ""
 	}
 
 	switch {
 	case tomlTree.Get(nameConst) == pkgName && !isEmpty(tomlTree, versionConst):
-		return true, tomlTree.Get(versionConst).(string)
+		return tomlTree.Get(versionConst).(string), true
 	case tomlTree.Get(nameConst) == pkgName && !isEmpty(tomlTree, revisionConst):
-		return true, tomlTree.Get(revisionConst).(string)
+		return tomlTree.Get(revisionConst).(string), true
 	case tomlTree.Get(nameConst) == pkgName && !isEmpty(tomlTree, branchConst):
-		return true, tomlTree.Get(branchConst).(string)
+		return tomlTree.Get(branchConst).(string), true
 	}
 	return
 }

--- a/versionutils/repo_test.go
+++ b/versionutils/repo_test.go
@@ -1,0 +1,68 @@
+package versionutils_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/solo-io/go-utils/versionutils"
+)
+
+var _ = Describe("Repo", func() {
+
+	var (
+		err         error
+		tmpDir      string
+		tomlFile    string
+		tomlWrapper *TomlWrapper
+		tomlContent = `
+[[override]]
+  name = "github.com/solo-io/gloo"
+  branch = "master"
+
+[[constraint]]
+  name = "github.com/solo-io/service-mesh-hub"
+  revision = "f1cdf253cb03da85ed2af456140c38eb90bcb53b"
+
+[[constraint]]
+  name = "github.com/solo-io/supergloo"
+  version = "v0.3.25"
+`
+	)
+
+	BeforeEach(func() {
+		tmpDir, err = ioutil.TempDir("", "toml-parse-test-")
+		Expect(err).NotTo(HaveOccurred())
+		tomlFile = filepath.Join(tmpDir, "Gopkg.toml")
+		err = ioutil.WriteFile(tomlFile, []byte(tomlContent), 0700)
+		Expect(err).NotTo(HaveOccurred())
+
+		tomlWrapper, err = ParseFullTomlFromDir(tmpDir)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		_ = os.RemoveAll(tmpDir)
+	})
+
+	It("can get the version from when 'version' is specified", func() {
+		version, err := GetTomlVersion("github.com/solo-io/supergloo", tomlWrapper)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(version).To(Equal("v0.3.25"))
+	})
+
+	It("can get the version from when 'branch' is specified", func() {
+		version, err := GetTomlVersion("github.com/solo-io/gloo", tomlWrapper)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(version).To(Equal("master"))
+	})
+
+	It("can get the version from when 'revision' is specified", func() {
+		version, err := GetTomlVersion("github.com/solo-io/service-mesh-hub", tomlWrapper)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(version).To(Equal("f1cdf253cb03da85ed2af456140c38eb90bcb53b"))
+	})
+})


### PR DESCRIPTION
Consider all possible version fields (`version`, `branch`, `revision`) when retrieving a dependency version from a .toml file.
BOT NOTES: 
resolves https://github.com/solo-io/go-utils/issues/291