### PR TITLE
Allow selecting the resources from the helm manifest to assert against

### DIFF
--- a/changelog/v0.10.25/manifest-filter.yaml
+++ b/changelog/v0.10.25/manifest-filter.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NEW_FEATURE
+  description: Allow selecting which helm manifest resources you'd like to test against
+  issueLink: https://github.com/solo-io/go-utils/issues/337

--- a/manifesttestutils/util.go
+++ b/manifesttestutils/util.go
@@ -49,8 +49,8 @@ type TestManifest interface {
 	// run this callback on all the resources contained in this TestManifest
 	ExpectAll(callback func(*unstructured.Unstructured))
 
-	// expects a function that, given a resource from the test manifest, will return true
-	// if that resource should be included in the newly-constructed TestManifest that Select returns
+	// construct a new set of resources to make assertions against by collecting
+	// all the resources for which `selector` returns true
 	SelectResources(selector func(*unstructured.Unstructured) bool) TestManifest
 }
 


### PR DESCRIPTION

BOT NOTES: 
resolves https://github.com/solo-io/go-utils/issues/337