### PR TITLE
fix logging timestamps if stats server is enabled

### DIFF
--- a/changelog/v0.13.5/logging-timestamp.yaml
+++ b/changelog/v0.13.5/logging-timestamp.yaml
@@ -1,5 +1,5 @@
 changelog:
-  - type: BUGFIX
+  - type: FIX
     description: If the stats server was started up, we set our context's fallbackLogger to a default logger with an epoch timestamp. Now, we set it to the zapcore.ISO8601TimeEncoder format instead.
     issueLink: https://github.com/solo-io/solo-projects/issues/1246
     resolvesIssue: false

--- a/changelog/v0.13.5/logging-timestamp.yaml
+++ b/changelog/v0.13.5/logging-timestamp.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: BUGFIX
+    description: If the stats server was started up, we set our context's fallbackLogger to a default logger with an epoch timestamp. Now, we set it to the zapcore.ISO8601TimeEncoder format instead.
+    issueLink: https://github.com/solo-io/solo-projects/issues/1246

--- a/changelog/v0.13.5/logging-timestamp.yaml
+++ b/changelog/v0.13.5/logging-timestamp.yaml
@@ -2,3 +2,4 @@ changelog:
   - type: BUGFIX
     description: If the stats server was started up, we set our context's fallbackLogger to a default logger with an epoch timestamp. Now, we set it to the zapcore.ISO8601TimeEncoder format instead.
     issueLink: https://github.com/solo-io/solo-projects/issues/1246
+    resolvesIssue: false

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -2,6 +2,7 @@ package stats
 
 import (
 	"fmt"
+	"go.uber.org/zap/zapcore"
 	"os"
 	"sort"
 	"text/template"
@@ -56,6 +57,7 @@ func StartStatsServerWithPort(startupOpts StartupOptions, addhandlers ...func(mu
 	}
 
 	logconfig := zap.NewProductionConfig()
+	logconfig.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 
 	logger, logerr := logconfig.Build()
 	contextutils.SetFallbackLogger(logger.Sugar())


### PR DESCRIPTION
In StartStatsServerWithPort, we set the fallback logger for a ctx with `contextutils.SetFallbackLogger(logger.Sugar())`, building a default logger that uses an epoch timestamp.

By default, we actually want the zapcore.ISO8601TimeEncoder format instead since it is more human-readable.