### PR TITLE
Ensure release asset file is open before attempting upload in retry loop

### DIFF
--- a/changelog/v0.14.1/fix-github-500-retry-logic.yaml
+++ b/changelog/v0.14.1/fix-github-500-retry-logic.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Fix github release asset upload logic to handle github 500 errors
+    issueLink: https://github.com/solo-io/go-utils/issues/394

--- a/githubutils/upload_release_asset.go
+++ b/githubutils/upload_release_asset.go
@@ -80,7 +80,7 @@ func uploadFileOrExit(ctx context.Context, client *github.Client, release *githu
 
 func tryUploadAsset(ctx context.Context, client *github.Client, release *github.RepositoryRelease, spec *UploadReleaseAssetSpec, name string, path string) error {
 
-	// we need to open/close the file in the here because it's in the retry loop
+	// we need to open/close the file here because it's in the retry loop
 	// we have seen when github is down and returns http 500 that it also closes the file we were trying to upload
 	// hence we need to ensure that the file is open before we attempt uploading the asset
 	file, err := os.Open(path)


### PR DESCRIPTION
Open and close the file within the retry loop so that if the github client closes it after an HTTP 500 failure, when we retry, the file is open before we attempt upload.

BOT NOTES: 
resolves https://github.com/solo-io/go-utils/issues/394