### PR TITLE
Add a function for getting clientcmd config with context

### DIFF
--- a/changelog/v0.15.3/clientcmd-config.yaml
+++ b/changelog/v0.15.3/clientcmd-config.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NEW_FEATURE
+    description: Add a function for getting clientcmd config with context.
+    issueLink: https://github.com/solo-io/go-utils/issues/403

--- a/kubeutils/kube_cfg.go
+++ b/kubeutils/kube_cfg.go
@@ -49,3 +49,14 @@ func GetKubeConfig(masterURL, kubeconfigPath string) (*clientcmdapi.Config, erro
 
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides).ConfigAccess().GetStartingConfig()
 }
+
+func GetKubeConfigWithContext(masterURL, kubeconfigPath, context string) (*clientcmdapi.Config, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	loadingRules.ExplicitPath = kubeconfigPath
+	configOverrides := &clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: masterURL}}
+	if context != "" {
+		configOverrides.CurrentContext = context
+	}
+
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides).ConfigAccess().GetStartingConfig()
+}


### PR DESCRIPTION

BOT NOTES: 
resolves https://github.com/solo-io/go-utils/issues/403