### PR TITLE
Set level with environment variable

### DIFF
--- a/changelog/v0.20.5/add-log-level-changing-via-env-var.yaml
+++ b/changelog/v0.20.5/add-log-level-changing-via-env-var.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NEW_FEATURE
+    description: Add ability to set log level from an environment variable
+    issueLink: https://github.com/solo-io/gloo/issues/4090

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -70,6 +70,10 @@ func StartStatsServerWithPort(startupOpts StartupOptions, addhandlers ...func(mu
 			setLevel = zapcore.WarnLevel
 		case "error":
 			setLevel = zapcore.ErrorLevel
+		case "panic":
+			setLevel = zapcore.PanicLevel
+		case "fatal":
+			setLevel = zapcore.FatalLevel
 		default:
 			setLevel = zapcore.InfoLevel
 		}


### PR DESCRIPTION
This PR updates the stats server so that the log level can be set by the environment variable that is present on start. My plan is to add this environment variable into the Helm templates so that it can be configured by the values overrides.

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/4090