### PR TITLE
Grpc health checker supports default value

### DIFF
--- a/changelog/v0.21.0/fix-homebrew-formula-regex.yaml
+++ b/changelog/v0.21.0/fix-homebrew-formula-regex.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: BREAKING_CHANGE
+    description: Allow injecting an initial serving status to the grpc health checker

--- a/changelog/v0.21.0/fix-homebrew-formula-regex.yaml
+++ b/changelog/v0.21.0/fix-homebrew-formula-regex.yaml
@@ -1,3 +1,5 @@
 changelog:
   - type: BREAKING_CHANGE
+    issueLink: https://github.com/solo-io/gloo/issues/2549
+    resolvesIssue: false
     description: Allow injecting an initial serving status to the grpc health checker

--- a/healthchecker/grpc.go
+++ b/healthchecker/grpc.go
@@ -21,12 +21,12 @@ type grpcHealthChecker struct {
 
 var _ HealthChecker = new(grpcHealthChecker)
 
-func NewGrpc(serviceName string, grpcHealthServer *health.Server, failOnTerm bool) *grpcHealthChecker {
+func NewGrpc(serviceName string, grpcHealthServer *health.Server, failOnTerm bool, initialServingStatus healthpb.HealthCheckResponse_ServingStatus) *grpcHealthChecker {
 	hc := &grpcHealthChecker{}
 	hc.name = serviceName
 
 	hc.srv = grpcHealthServer
-	hc.srv.SetServingStatus(serviceName, healthpb.HealthCheckResponse_SERVING)
+	hc.srv.SetServingStatus(serviceName, initialServingStatus)
 
 	// TODO(yuval-k): we should remove this, as this shouldn't be done by this component, and
 	// cannot be unit tested.

--- a/healthchecker/grpc_test.go
+++ b/healthchecker/grpc_test.go
@@ -32,7 +32,7 @@ func RunServer(ctx context.Context) *testGRPCServer {
 	}
 	grpcServer := grpc.NewServer()
 	reflection.Register(grpcServer)
-	hc := healthchecker.NewGrpc(serviceName, health.NewServer(), false)
+	hc := healthchecker.NewGrpc(serviceName, health.NewServer(), false, healthpb.HealthCheckResponse_SERVING)
 	healthpb.RegisterHealthServer(grpcServer, hc.GetServer())
 	go grpcServer.Serve(lis)
 	time.Sleep(time.Millisecond)


### PR DESCRIPTION
The grpc health checker used to default to serving. We should allow the client to inject the initial serving status. This PR enables that.