### PR TITLE
Custom tag comparator

### DIFF
--- a/changelog/v0.21.2/add-custom-order-tag-label.yaml
+++ b/changelog/v0.21.2/add-custom-order-tag-label.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NEW_FEATURE
+    description: >
+      Adds `labelOrder` to changelogValidator. If `labelOrder` exists, then changelogValidator
+      will now use the order specified in this array to tie-break tags with same versions but different labels.
+      e.g. if e.g. labelOrder = [ beta, alpha, predev ], then 1.7.0-beta11 > 1.7.0-alpha5 > 1.7.0-predev9.

--- a/changelog/v0.21.2/add-custom-order-tag-label.yaml
+++ b/changelog/v0.21.2/add-custom-order-tag-label.yaml
@@ -4,3 +4,4 @@ changelog:
       Adds `labelOrder` to changelogValidator. If `labelOrder` exists, then changelogValidator
       will now use the order specified in this array to tie-break tags with same versions but different labels.
       e.g. if e.g. labelOrder = [ beta, alpha, predev ], then 1.7.0-beta11 > 1.7.0-alpha5 > 1.7.0-predev9.
+    issueLink: https://github.com/solo-io/go-utils/issues/441

--- a/changelogutils/changelog_test.go
+++ b/changelogutils/changelog_test.go
@@ -28,7 +28,7 @@ var _ = Describe("ChangelogTest", func() {
 			return actualErr
 		}
 
-		It("works", func() {
+		FIt("works", func() {
 			tmpDir := mustWriteTestDir()
 			defer os.RemoveAll(tmpDir)
 			changelogDir := filepath.Join(tmpDir, changelogutils.ChangelogDirectory)
@@ -44,6 +44,8 @@ var _ = Describe("ChangelogTest", func() {
 			Expect(getProposedTag("v1.0.0-beta1", tmpDir, "v1.0.0-beta2")).To(BeNil())
 			Expect(createSubdirs(changelogDir, "v1.0.0-rc1")).To(BeNil())
 			Expect(getProposedTag("v1.0.0-beta2", tmpDir, "v1.0.0-rc1")).To(BeNil())
+			Expect(createSubdirs(changelogDir, "v1.0.0-rc2")).To(BeNil())
+			Expect(getProposedTag("v1.0.0-rc1", tmpDir, "")).NotTo(BeNil())
 
 			// add a directory without 'v' prefix, which should be parsed as invalid
 			Expect(createSubdirs(changelogDir, "1.0.0-beta3")).To(BeNil())

--- a/changelogutils/changelog_test.go
+++ b/changelogutils/changelog_test.go
@@ -28,7 +28,7 @@ var _ = Describe("ChangelogTest", func() {
 			return actualErr
 		}
 
-		FIt("works", func() {
+		It("works", func() {
 			tmpDir := mustWriteTestDir()
 			defer os.RemoveAll(tmpDir)
 			changelogDir := filepath.Join(tmpDir, changelogutils.ChangelogDirectory)

--- a/changelogutils/validator_test.go
+++ b/changelogutils/validator_test.go
@@ -36,205 +36,193 @@ var _ = Describe("changelog validator utils", func() {
 		ctrl = gomock.NewController(test)
 		code = NewMockMountedRepo(ctrl)
 		repoClient = NewMockRepoClient(ctrl)
-		validator = changelogutils.NewChangelogValidator(repoClient, code, base)
 	})
 
 	AfterEach(func() {
 		ctrl.Finish()
 	})
 
-	Context("should check changelog", func() {
-		It("should check if master has changelog", func() {
-			repoClient.EXPECT().
-				DirectoryExists(ctx, changelogutils.MasterBranch, changelogutils.ChangelogDirectory).
-				Return(true, nil)
-
-			check, err := validator.ShouldCheckChangelog(ctx)
-			Expect(err).To(BeNil())
-			Expect(check).To(BeTrue())
-		})
-
-		It("should not check if error looking at master", func() {
-			repoClient.EXPECT().
-				DirectoryExists(ctx, changelogutils.MasterBranch, changelogutils.ChangelogDirectory).
-				Return(false, nestedErr)
-
-			check, err := validator.ShouldCheckChangelog(ctx)
-			Expect(err).To(Equal(nestedErr))
-			Expect(check).To(BeFalse())
-		})
-
-		It("should check if sha has changelog but master doesn't", func() {
-			repoClient.EXPECT().
-				DirectoryExists(ctx, changelogutils.MasterBranch, changelogutils.ChangelogDirectory).
-				Return(false, nil)
-			code.EXPECT().GetSha().Return(sha)
-			repoClient.EXPECT().
-				DirectoryExists(ctx, sha, changelogutils.ChangelogDirectory).
-				Return(true, nil)
-
-			check, err := validator.ShouldCheckChangelog(ctx)
-			Expect(err).To(BeNil())
-			Expect(check).To(BeTrue())
-		})
-
-		It("shouldn't check if sha and master don't have changelog", func() {
-			repoClient.EXPECT().
-				DirectoryExists(ctx, changelogutils.MasterBranch, changelogutils.ChangelogDirectory).
-				Return(false, nil)
-			code.EXPECT().GetSha().Return(sha)
-			repoClient.EXPECT().
-				DirectoryExists(ctx, sha, changelogutils.ChangelogDirectory).
-				Return(false, nil)
-
-			check, err := validator.ShouldCheckChangelog(ctx)
-			Expect(err).To(BeNil())
-			Expect(check).To(BeFalse())
-		})
-
-		It("shouldn't check if error looking at sha", func() {
-			repoClient.EXPECT().
-				DirectoryExists(ctx, changelogutils.MasterBranch, changelogutils.ChangelogDirectory).
-				Return(false, nil)
-			code.EXPECT().GetSha().Return(sha)
-			repoClient.EXPECT().
-				DirectoryExists(ctx, sha, changelogutils.ChangelogDirectory).
-				Return(false, nestedErr)
-
-			check, err := validator.ShouldCheckChangelog(ctx)
-			Expect(err).To(Equal(nestedErr))
-			Expect(check).To(BeFalse())
-		})
-	})
-
-	Context("validate changelog", func() {
-
-		const (
-			filename1 = "1.yaml"
-			filename2 = "2.yaml"
-			filename3 = "3.yaml"
-			tag       = "v0.5.1"
-			nextTag   = "v0.5.2"
-		)
-
-		var (
-			path1          = filepath.Join(changelogutils.ChangelogDirectory, tag, filename1)
-			path2          = filepath.Join(changelogutils.ChangelogDirectory, tag, filename2)
-			added          = githubutils.COMMIT_FILE_STATUS_ADDED
-			unexpectedFile = mockFileInfo{isDir: false, name: "unexpected"}
-
-			path3 = filepath.Join(changelogutils.ChangelogDirectory, nextTag, filename3)
-		)
-
-		relaxedValidationSettingsExists := func() {
-			repoClient.EXPECT().FileExists(ctx, sha, changelogutils.GetValidationSettingsPath()).Return(true, nil)
-			code.EXPECT().GetFileContents(ctx, changelogutils.GetValidationSettingsPath()).Return([]byte(validationYaml), nil)
-		}
-
-		noValidationSettingsExist := func() {
-			repoClient.EXPECT().FileExists(ctx, sha, changelogutils.GetValidationSettingsPath()).Return(false, nil)
-		}
-
-		getChangelogDir := func(tag string) os.FileInfo {
-			return &mockFileInfo{name: tag, isDir: true}
-		}
-
-		validateVersionBump := func(lastTag, nextTag, contents string, expectFailure bool) {
-
-			nextTagFile := filepath.Join(changelogutils.ChangelogDirectory, nextTag, filename1)
-			cc := github.CommitsComparison{Files: []*github.CommitFile{{Filename: &nextTagFile, Status: &added}}}
-
-			repoClient.EXPECT().
-				CompareCommits(ctx, base, sha).
-				Return(&cc, nil)
-
-			code.EXPECT().
-				GetFileContents(ctx, nextTagFile).
-				Return([]byte(contents), nil).Times(2)
-
-			repoClient.EXPECT().
-				FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-				Return(lastTag, nil)
-
-			code.EXPECT().
-				ListFiles(ctx, changelogutils.ChangelogDirectory).
-				Return([]os.FileInfo{getChangelogDir(nextTag)}, nil)
-
-			code.EXPECT().
-				ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, nextTag)).
-				Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
-
-			file, err := validator.ValidateChangelog(ctx)
-
-			if expectFailure {
-				Expect(err).To(HaveOccurred())
-				Expect(file).To(BeNil())
-			} else {
-				Expect(err).NotTo(HaveOccurred())
-				Expect(file).NotTo(BeNil())
-			}
-		}
-
+	Context("With default tag validator", func() {
 		BeforeEach(func() {
-			// so should check returns true
-			repoClient.EXPECT().
-				DirectoryExists(ctx, changelogutils.MasterBranch, changelogutils.ChangelogDirectory).
-				Return(true, nil)
-			code.EXPECT().GetSha().Return(sha).AnyTimes()
+			validator = changelogutils.NewChangelogValidator(repoClient, code, base)
 		})
 
-		It("propagates error comparing commits", func() {
-			repoClient.EXPECT().
-				CompareCommits(ctx, base, sha).
-				Return(nil, nestedErr)
-			file, err := validator.ValidateChangelog(ctx)
-			Expect(file).To(BeNil())
-			Expect(err).To(Equal(nestedErr))
+		Context("should check changelog", func() {
+			It("should check if master has changelog", func() {
+				repoClient.EXPECT().
+					DirectoryExists(ctx, changelogutils.MasterBranch, changelogutils.ChangelogDirectory).
+					Return(true, nil)
+
+				check, err := validator.ShouldCheckChangelog(ctx)
+				Expect(err).To(BeNil())
+				Expect(check).To(BeTrue())
+			})
+
+			It("should not check if error looking at master", func() {
+				repoClient.EXPECT().
+					DirectoryExists(ctx, changelogutils.MasterBranch, changelogutils.ChangelogDirectory).
+					Return(false, nestedErr)
+
+				check, err := validator.ShouldCheckChangelog(ctx)
+				Expect(err).To(Equal(nestedErr))
+				Expect(check).To(BeFalse())
+			})
+
+			It("should check if sha has changelog but master doesn't", func() {
+				repoClient.EXPECT().
+					DirectoryExists(ctx, changelogutils.MasterBranch, changelogutils.ChangelogDirectory).
+					Return(false, nil)
+				code.EXPECT().GetSha().Return(sha)
+				repoClient.EXPECT().
+					DirectoryExists(ctx, sha, changelogutils.ChangelogDirectory).
+					Return(true, nil)
+
+				check, err := validator.ShouldCheckChangelog(ctx)
+				Expect(err).To(BeNil())
+				Expect(check).To(BeTrue())
+			})
+
+			It("shouldn't check if sha and master don't have changelog", func() {
+				repoClient.EXPECT().
+					DirectoryExists(ctx, changelogutils.MasterBranch, changelogutils.ChangelogDirectory).
+					Return(false, nil)
+				code.EXPECT().GetSha().Return(sha)
+				repoClient.EXPECT().
+					DirectoryExists(ctx, sha, changelogutils.ChangelogDirectory).
+					Return(false, nil)
+
+				check, err := validator.ShouldCheckChangelog(ctx)
+				Expect(err).To(BeNil())
+				Expect(check).To(BeFalse())
+			})
+
+			It("shouldn't check if error looking at sha", func() {
+				repoClient.EXPECT().
+					DirectoryExists(ctx, changelogutils.MasterBranch, changelogutils.ChangelogDirectory).
+					Return(false, nil)
+				code.EXPECT().GetSha().Return(sha)
+				repoClient.EXPECT().
+					DirectoryExists(ctx, sha, changelogutils.ChangelogDirectory).
+					Return(false, nestedErr)
+
+				check, err := validator.ShouldCheckChangelog(ctx)
+				Expect(err).To(Equal(nestedErr))
+				Expect(check).To(BeFalse())
+			})
 		})
 
-		It("errors when no changelog file added", func() {
-			cc := github.CommitsComparison{}
-			repoClient.EXPECT().
-				CompareCommits(ctx, base, sha).
-				Return(&cc, nil)
+		Context("validate changelog", func() {
 
-			expected := changelogutils.NoChangelogFileAddedError
-			file, err := validator.ValidateChangelog(ctx)
-			Expect(file).To(BeNil())
-			Expect(err).To(Equal(expected))
-		})
+			const (
+				filename1 = "1.yaml"
+				filename2 = "2.yaml"
+				filename3 = "3.yaml"
+				tag       = "v0.5.1"
+				nextTag   = "v0.5.2"
+			)
 
-		It("errors when more than one changelog file added", func() {
-			file1 := github.CommitFile{Filename: &path1, Status: &added}
-			file2 := github.CommitFile{Filename: &path2, Status: &added}
-			cc := github.CommitsComparison{Files: []*github.CommitFile{&file1, &file2}}
-			repoClient.EXPECT().
-				CompareCommits(ctx, base, sha).
-				Return(&cc, nil)
+			var (
+				path1          = filepath.Join(changelogutils.ChangelogDirectory, tag, filename1)
+				path2          = filepath.Join(changelogutils.ChangelogDirectory, tag, filename2)
+				added          = githubutils.COMMIT_FILE_STATUS_ADDED
+				unexpectedFile = mockFileInfo{isDir: false, name: "unexpected"}
 
-			expected := changelogutils.TooManyChangelogFilesAddedError(2)
-			file, err := validator.ValidateChangelog(ctx)
-			Expect(file).To(BeNil())
-			Expect(err.Error()).To(Equal(expected.Error()))
-		})
+				path3 = filepath.Join(changelogutils.ChangelogDirectory, nextTag, filename3)
+			)
 
-		It("errors when getting changelog file contents fails", func() {
-			file1 := github.CommitFile{Filename: &path1, Status: &added}
-			cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
-			repoClient.EXPECT().
-				CompareCommits(ctx, base, sha).
-				Return(&cc, nil)
-			code.EXPECT().
-				GetFileContents(ctx, path1).
-				Return(nil, nestedErr)
+			relaxedValidationSettingsExists := func() {
+				repoClient.EXPECT().FileExists(ctx, sha, changelogutils.GetValidationSettingsPath()).Return(true, nil)
+				code.EXPECT().GetFileContents(ctx, changelogutils.GetValidationSettingsPath()).Return([]byte(validationYaml), nil)
+			}
 
-			file, err := validator.ValidateChangelog(ctx)
-			Expect(file).To(BeNil())
-			Expect(err).To(Equal(nestedErr))
-		})
+			noValidationSettingsExist := func() {
+				repoClient.EXPECT().FileExists(ctx, sha, changelogutils.GetValidationSettingsPath()).Return(false, nil)
+			}
 
-		Context("validating proposed tag", func() {
+			getChangelogDir := func(tag string) os.FileInfo {
+				return &mockFileInfo{name: tag, isDir: true}
+			}
+
+			validateVersionBump := func(lastTag, nextTag, contents string, expectFailure bool) {
+
+				nextTagFile := filepath.Join(changelogutils.ChangelogDirectory, nextTag, filename1)
+				cc := github.CommitsComparison{Files: []*github.CommitFile{{Filename: &nextTagFile, Status: &added}}}
+
+				repoClient.EXPECT().
+					CompareCommits(ctx, base, sha).
+					Return(&cc, nil)
+
+				code.EXPECT().
+					GetFileContents(ctx, nextTagFile).
+					Return([]byte(contents), nil).Times(2)
+
+				repoClient.EXPECT().
+					FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+					Return(lastTag, nil)
+
+				code.EXPECT().
+					ListFiles(ctx, changelogutils.ChangelogDirectory).
+					Return([]os.FileInfo{getChangelogDir(nextTag)}, nil)
+
+				code.EXPECT().
+					ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, nextTag)).
+					Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
+
+				file, err := validator.ValidateChangelog(ctx)
+
+				if expectFailure {
+					Expect(err).To(HaveOccurred())
+					Expect(file).To(BeNil())
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(file).NotTo(BeNil())
+				}
+			}
+
 			BeforeEach(func() {
+				// so should check returns true
+				repoClient.EXPECT().
+					DirectoryExists(ctx, changelogutils.MasterBranch, changelogutils.ChangelogDirectory).
+					Return(true, nil)
+				code.EXPECT().GetSha().Return(sha).AnyTimes()
+			})
+
+			It("propagates error comparing commits", func() {
+				repoClient.EXPECT().
+					CompareCommits(ctx, base, sha).
+					Return(nil, nestedErr)
+				file, err := validator.ValidateChangelog(ctx)
+				Expect(file).To(BeNil())
+				Expect(err).To(Equal(nestedErr))
+			})
+
+			It("errors when no changelog file added", func() {
+				cc := github.CommitsComparison{}
+				repoClient.EXPECT().
+					CompareCommits(ctx, base, sha).
+					Return(&cc, nil)
+
+				expected := changelogutils.NoChangelogFileAddedError
+				file, err := validator.ValidateChangelog(ctx)
+				Expect(file).To(BeNil())
+				Expect(err).To(Equal(expected))
+			})
+
+			It("errors when more than one changelog file added", func() {
+				file1 := github.CommitFile{Filename: &path1, Status: &added}
+				file2 := github.CommitFile{Filename: &path2, Status: &added}
+				cc := github.CommitsComparison{Files: []*github.CommitFile{&file1, &file2}}
+				repoClient.EXPECT().
+					CompareCommits(ctx, base, sha).
+					Return(&cc, nil)
+
+				expected := changelogutils.TooManyChangelogFilesAddedError(2)
+				file, err := validator.ValidateChangelog(ctx)
+				Expect(file).To(BeNil())
+				Expect(err.Error()).To(Equal(expected.Error()))
+			})
+
+			It("errors when getting changelog file contents fails", func() {
 				file1 := github.CommitFile{Filename: &path1, Status: &added}
 				cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
 				repoClient.EXPECT().
@@ -242,111 +230,574 @@ var _ = Describe("changelog validator utils", func() {
 					Return(&cc, nil)
 				code.EXPECT().
 					GetFileContents(ctx, path1).
-					Return([]byte(validChangelog1), nil)
-			})
+					Return(nil, nestedErr)
 
-			It("propagates error listing releases", func() {
-				repoClient.EXPECT().
-					FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-					Return("", nestedErr)
-
-				expected := changelogutils.ListReleasesError(nestedErr)
 				file, err := validator.ValidateChangelog(ctx)
 				Expect(file).To(BeNil())
-				Expect(err.Error()).To(Equal(expected.Error()))
+				Expect(err).To(Equal(nestedErr))
 			})
 
-			It("errors when unexpected file in changelog directory", func() {
-				repoClient.EXPECT().
-					FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-					Return(tag, nil)
-				code.EXPECT().
-					ListFiles(ctx, changelogutils.ChangelogDirectory).
-					Return([]os.FileInfo{&unexpectedFile}, nil)
-
-				expected := changelogutils.UnexpectedFileInChangelogDirectoryError(unexpectedFile.name)
-				file, err := validator.ValidateChangelog(ctx)
-				Expect(file).To(BeNil())
-				Expect(err.Error()).To(Equal(expected.Error()))
-			})
-
-			It("errors when invalid tag in changelog directory", func() {
-				repoClient.EXPECT().
-					FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-					Return(tag, nil)
-				code.EXPECT().
-					ListFiles(ctx, changelogutils.ChangelogDirectory).
-					Return([]os.FileInfo{getChangelogDir("invalid-tag")}, nil)
-
-				expected := changelogutils.InvalidChangelogSubdirectoryNameError("invalid-tag")
-				file, err := validator.ValidateChangelog(ctx)
-				Expect(file).To(BeNil())
-				Expect(err.Error()).To(Equal(expected.Error()))
-			})
-
-			It("errors when no new version", func() {
-				repoClient.EXPECT().
-					FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-					Return(tag, nil)
-				code.EXPECT().
-					ListFiles(ctx, changelogutils.ChangelogDirectory).
-					Return([]os.FileInfo{getChangelogDir(tag)}, nil)
-
-				expected := changelogutils.NoNewVersionsFoundError(tag)
-				file, err := validator.ValidateChangelog(ctx)
-				Expect(file).To(BeNil())
-				Expect(err.Error()).To(Equal(expected.Error()))
-			})
-
-			It("errors when no too many new versions", func() {
-				repoClient.EXPECT().
-					FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-					Return(tag, nil)
-				code.EXPECT().
-					ListFiles(ctx, changelogutils.ChangelogDirectory).
-					Return([]os.FileInfo{getChangelogDir("v0.5.2"), getChangelogDir("v0.5.3")}, nil)
-
-				expected := changelogutils.MultipleNewVersionsFoundError(tag, "v0.5.2", "v0.5.3")
-				file, err := validator.ValidateChangelog(ctx)
-				Expect(file).To(BeNil())
-				Expect(err.Error()).To(Equal(expected.Error()))
-			})
-
-			It("errors when added changelog to old version", func() {
-				repoClient.EXPECT().
-					FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-					Return(tag, nil)
-				code.EXPECT().
-					ListFiles(ctx, changelogutils.ChangelogDirectory).
-					Return([]os.FileInfo{getChangelogDir(nextTag)}, nil)
-				code.EXPECT().
-					ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, nextTag)).
-					Return([]os.FileInfo{&mockFileInfo{name: filename3, isDir: false}}, nil)
-				code.EXPECT().
-					GetFileContents(ctx, path3).
-					Return([]byte(validChangelog2), nil)
-				repoClient.EXPECT().
-					FileExists(ctx, sha, changelogutils.GetValidationSettingsPath()).
-					Return(false, nil)
-				expected := changelogutils.AddedChangelogInOldVersionError(nextTag)
-				file, err := validator.ValidateChangelog(ctx)
-				Expect(file).To(BeNil())
-				Expect(err.Error()).To(Equal(expected.Error()))
-			})
-
-		})
-
-		Context("incrementing versions", func() {
-
-			BeforeEach(func() {
-				noValidationSettingsExist()
-			})
-
-			Context("major version zero 0.y.z", func() {
-
-				It("works on patch version bump", func() {
+			Context("validating proposed tag", func() {
+				BeforeEach(func() {
 					file1 := github.CommitFile{Filename: &path1, Status: &added}
 					cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
+					repoClient.EXPECT().
+						CompareCommits(ctx, base, sha).
+						Return(&cc, nil)
+					code.EXPECT().
+						GetFileContents(ctx, path1).
+						Return([]byte(validChangelog1), nil)
+				})
+
+				It("propagates error listing releases", func() {
+					repoClient.EXPECT().
+						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+						Return("", nestedErr)
+
+					expected := changelogutils.ListReleasesError(nestedErr)
+					file, err := validator.ValidateChangelog(ctx)
+					Expect(file).To(BeNil())
+					Expect(err.Error()).To(Equal(expected.Error()))
+				})
+
+				It("errors when unexpected file in changelog directory", func() {
+					repoClient.EXPECT().
+						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+						Return(tag, nil)
+					code.EXPECT().
+						ListFiles(ctx, changelogutils.ChangelogDirectory).
+						Return([]os.FileInfo{&unexpectedFile}, nil)
+
+					expected := changelogutils.UnexpectedFileInChangelogDirectoryError(unexpectedFile.name)
+					file, err := validator.ValidateChangelog(ctx)
+					Expect(file).To(BeNil())
+					Expect(err.Error()).To(Equal(expected.Error()))
+				})
+
+				It("errors when invalid tag in changelog directory", func() {
+					repoClient.EXPECT().
+						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+						Return(tag, nil)
+					code.EXPECT().
+						ListFiles(ctx, changelogutils.ChangelogDirectory).
+						Return([]os.FileInfo{getChangelogDir("invalid-tag")}, nil)
+
+					expected := changelogutils.InvalidChangelogSubdirectoryNameError("invalid-tag")
+					file, err := validator.ValidateChangelog(ctx)
+					Expect(file).To(BeNil())
+					Expect(err.Error()).To(Equal(expected.Error()))
+				})
+
+				It("errors when no new version", func() {
+					repoClient.EXPECT().
+						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+						Return(tag, nil)
+					code.EXPECT().
+						ListFiles(ctx, changelogutils.ChangelogDirectory).
+						Return([]os.FileInfo{getChangelogDir(tag)}, nil)
+
+					expected := changelogutils.NoNewVersionsFoundError(tag)
+					file, err := validator.ValidateChangelog(ctx)
+					Expect(file).To(BeNil())
+					Expect(err.Error()).To(Equal(expected.Error()))
+				})
+
+				It("errors when no too many new versions", func() {
+					repoClient.EXPECT().
+						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+						Return(tag, nil)
+					code.EXPECT().
+						ListFiles(ctx, changelogutils.ChangelogDirectory).
+						Return([]os.FileInfo{getChangelogDir("v0.5.2"), getChangelogDir("v0.5.3")}, nil)
+
+					expected := changelogutils.MultipleNewVersionsFoundError(tag, "v0.5.2", "v0.5.3")
+					file, err := validator.ValidateChangelog(ctx)
+					Expect(file).To(BeNil())
+					Expect(err.Error()).To(Equal(expected.Error()))
+				})
+
+				It("errors when added changelog to old version", func() {
+					repoClient.EXPECT().
+						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+						Return(tag, nil)
+					code.EXPECT().
+						ListFiles(ctx, changelogutils.ChangelogDirectory).
+						Return([]os.FileInfo{getChangelogDir(nextTag)}, nil)
+					code.EXPECT().
+						ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, nextTag)).
+						Return([]os.FileInfo{&mockFileInfo{name: filename3, isDir: false}}, nil)
+					code.EXPECT().
+						GetFileContents(ctx, path3).
+						Return([]byte(validChangelog2), nil)
+					repoClient.EXPECT().
+						FileExists(ctx, sha, changelogutils.GetValidationSettingsPath()).
+						Return(false, nil)
+					expected := changelogutils.AddedChangelogInOldVersionError(nextTag)
+					file, err := validator.ValidateChangelog(ctx)
+					Expect(file).To(BeNil())
+					Expect(err.Error()).To(Equal(expected.Error()))
+				})
+
+			})
+
+			Context("incrementing versions", func() {
+
+				BeforeEach(func() {
+					noValidationSettingsExist()
+				})
+
+				Context("major version zero 0.y.z", func() {
+
+					It("works on patch version bump", func() {
+						file1 := github.CommitFile{Filename: &path1, Status: &added}
+						cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
+						repoClient.EXPECT().
+							CompareCommits(ctx, base, sha).
+							Return(&cc, nil)
+						code.EXPECT().
+							GetFileContents(ctx, path1).
+							Return([]byte(validChangelog1), nil).Times(2)
+						repoClient.EXPECT().
+							FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+							Return("v0.5.0", nil)
+						code.EXPECT().
+							ListFiles(ctx, changelogutils.ChangelogDirectory).
+							Return([]os.FileInfo{getChangelogDir(tag)}, nil)
+						code.EXPECT().
+							ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, tag)).
+							Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
+						file, err := validator.ValidateChangelog(ctx)
+						Expect(file).NotTo(BeNil())
+						Expect(err).To(BeNil())
+					})
+
+					It("errors when not incrementing major version", func() {
+						file1 := github.CommitFile{Filename: &path1, Status: &added}
+						cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
+						repoClient.EXPECT().
+							CompareCommits(ctx, base, sha).
+							Return(&cc, nil)
+						code.EXPECT().
+							GetFileContents(ctx, path1).
+							Return([]byte(validBreakingChangelog), nil).Times(2)
+						repoClient.EXPECT().
+							FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+							Return("v0.5.0", nil)
+						code.EXPECT().
+							ListFiles(ctx, changelogutils.ChangelogDirectory).
+							Return([]os.FileInfo{getChangelogDir(tag)}, nil)
+						code.EXPECT().
+							ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, tag)).
+							Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
+
+						expected := changelogutils.UnexpectedProposedVersionError("v0.6.0", tag)
+						file, err := validator.ValidateChangelog(ctx)
+						Expect(file).To(BeNil())
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(Equal(expected.Error()))
+					})
+
+					It("works when incrementing major version", func() {
+						path := filepath.Join(changelogutils.ChangelogDirectory, "v0.6.0", filename1)
+						file1 := github.CommitFile{Filename: &path, Status: &added}
+						cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
+						repoClient.EXPECT().
+							CompareCommits(ctx, base, sha).
+							Return(&cc, nil)
+						code.EXPECT().
+							GetFileContents(ctx, path).
+							Return([]byte(validBreakingChangelog), nil).Times(2)
+						repoClient.EXPECT().
+							FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+							Return("v0.5.0", nil)
+						code.EXPECT().
+							ListFiles(ctx, changelogutils.ChangelogDirectory).
+							Return([]os.FileInfo{getChangelogDir("v0.6.0")}, nil)
+						code.EXPECT().
+							ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, "v0.6.0")).
+							Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
+
+						file, err := validator.ValidateChangelog(ctx)
+						Expect(err).To(BeNil())
+						Expect(file).NotTo(BeNil())
+					})
+
+				})
+
+				Context("major version is 1.y.z", func() {
+
+					DescribeTable("correctly enforces version bump rules",
+						validateVersionBump,
+						Entry("breaking change with patch bump", "v1.0.0", "v1.0.1", validBreakingChangelog, true),
+						Entry("breaking change with minor bump", "v1.0.0", "v1.1.0", validBreakingChangelog, true),
+						Entry("breaking change with major bump", "v1.0.0", "v2.0.0", validBreakingChangelog, false),
+						Entry("new feature with patch bump", "v1.0.0", "v1.0.1", validNewFeatureChangelog, true),
+						Entry("new feature with minor bump", "v1.0.0", "v1.1.0", validNewFeatureChangelog, false),
+						Entry("new feature with major bump", "v1.0.0", "v2.0.0", validNewFeatureChangelog, true),
+						Entry("non-breaking with patch bump", "v1.0.0", "v1.0.1", validNonBreakingNorNewFeatureChangelog, false),
+						Entry("non-breaking with minor bump", "v1.0.0", "v1.1.0", validNonBreakingNorNewFeatureChangelog, true),
+						Entry("non-breaking with major bump", "v1.0.0", "v2.0.0", validNonBreakingNorNewFeatureChangelog, true),
+					)
+				})
+
+				Context("moving from 0.x to 1.x", func() {
+
+					It("works for stable api release", func() {
+						path := filepath.Join(changelogutils.ChangelogDirectory, "v1.0.0", filename1)
+						file1 := github.CommitFile{Filename: &path, Status: &added}
+						cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
+						repoClient.EXPECT().
+							CompareCommits(ctx, base, sha).
+							Return(&cc, nil)
+						code.EXPECT().
+							GetFileContents(ctx, path).
+							Return([]byte(validStableReleaseChangelog), nil).Times(2)
+						repoClient.EXPECT().
+							FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+							Return("v0.5.0", nil)
+						code.EXPECT().
+							ListFiles(ctx, changelogutils.ChangelogDirectory).
+							Return([]os.FileInfo{getChangelogDir("v1.0.0")}, nil)
+						code.EXPECT().
+							ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, "v1.0.0")).
+							Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
+
+						file, err := validator.ValidateChangelog(ctx)
+						Expect(err).To(BeNil())
+						Expect(file).NotTo(BeNil())
+					})
+
+					It("errors when not incrementing for stable api release", func() {
+						path := filepath.Join(changelogutils.ChangelogDirectory, nextTag, filename1)
+						file1 := github.CommitFile{Filename: &path, Status: &added}
+						cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
+						repoClient.EXPECT().
+							CompareCommits(ctx, base, sha).
+							Return(&cc, nil)
+						code.EXPECT().
+							GetFileContents(ctx, path).
+							Return([]byte(validStableReleaseChangelog), nil).Times(2)
+						repoClient.EXPECT().
+							FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+							Return("v0.5.0", nil)
+						code.EXPECT().
+							ListFiles(ctx, changelogutils.ChangelogDirectory).
+							Return([]os.FileInfo{getChangelogDir(nextTag)}, nil)
+						code.EXPECT().
+							ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, nextTag)).
+							Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
+
+						expected := changelogutils.InvalidUseOfStableApiError(nextTag)
+						file, err := validator.ValidateChangelog(ctx)
+						Expect(err.Error()).To(Equal(expected.Error()))
+						Expect(file).To(BeNil())
+					})
+				})
+			})
+
+			Context("incrementing versions with relaxed validation", func() {
+
+				BeforeEach(func() {
+					relaxedValidationSettingsExists()
+				})
+
+				Context("major version zero 0.y.z", func() {
+
+					It("allows not incrementing major version", func() {
+						file1 := github.CommitFile{Filename: &path1, Status: &added}
+						cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
+						repoClient.EXPECT().
+							CompareCommits(ctx, base, sha).
+							Return(&cc, nil)
+						code.EXPECT().
+							GetFileContents(ctx, path1).
+							Return([]byte(validBreakingChangelog), nil).Times(2)
+						repoClient.EXPECT().
+							FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+							Return("v0.5.0", nil)
+						code.EXPECT().
+							ListFiles(ctx, changelogutils.ChangelogDirectory).
+							Return([]os.FileInfo{getChangelogDir(tag)}, nil)
+						code.EXPECT().
+							ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, tag)).
+							Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
+
+						file, err := validator.ValidateChangelog(ctx)
+						Expect(file).NotTo(BeNil())
+						Expect(err).To(BeNil())
+					})
+
+					It("works when incrementing major version", func() {
+						path := filepath.Join(changelogutils.ChangelogDirectory, "v0.6.0", filename1)
+						file1 := github.CommitFile{Filename: &path, Status: &added}
+						cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
+						repoClient.EXPECT().
+							CompareCommits(ctx, base, sha).
+							Return(&cc, nil)
+						code.EXPECT().
+							GetFileContents(ctx, path).
+							Return([]byte(validBreakingChangelog), nil).Times(2)
+						repoClient.EXPECT().
+							FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+							Return("v0.5.0", nil)
+						code.EXPECT().
+							ListFiles(ctx, changelogutils.ChangelogDirectory).
+							Return([]os.FileInfo{getChangelogDir("v0.6.0")}, nil)
+						code.EXPECT().
+							ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, "v0.6.0")).
+							Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
+
+						file, err := validator.ValidateChangelog(ctx)
+						Expect(err).To(BeNil())
+						Expect(file).NotTo(BeNil())
+					})
+
+				})
+
+				Context("major version is 1.y.z", func() {
+
+					DescribeTable("doesn't enforce version bump rules",
+						validateVersionBump,
+						Entry("breaking change with patch bump", "v1.0.0", "v1.0.1", validBreakingChangelog, false),
+						Entry("breaking change with minor bump", "v1.0.0", "v1.1.0", validBreakingChangelog, false),
+						Entry("breaking change with major bump", "v1.0.0", "v2.0.0", validBreakingChangelog, false),
+						Entry("new feature with patch bump", "v1.0.0", "v1.0.1", validNewFeatureChangelog, false),
+						Entry("new feature with minor bump", "v1.0.0", "v1.1.0", validNewFeatureChangelog, false),
+						Entry("new feature with major bump", "v1.0.0", "v2.0.0", validNewFeatureChangelog, false),
+						Entry("non-breaking with patch bump", "v1.0.0", "v1.0.1", validNonBreakingNorNewFeatureChangelog, false),
+						Entry("non-breaking with minor bump", "v1.0.0", "v1.1.0", validNonBreakingNorNewFeatureChangelog, false),
+						Entry("non-breaking with major bump", "v1.0.0", "v2.0.0", validNonBreakingNorNewFeatureChangelog, false),
+						Entry("stable release that skips to a future version", "v1.0.0-rc6", "v1.2.0", validNonBreakingNorNewFeatureChangelog, false),
+					)
+				})
+
+				Context("moving from 0.x to 1.x", func() {
+
+					It("works for stable api release", func() {
+						path := filepath.Join(changelogutils.ChangelogDirectory, "v1.0.0", filename1)
+						file1 := github.CommitFile{Filename: &path, Status: &added}
+						cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
+						repoClient.EXPECT().
+							CompareCommits(ctx, base, sha).
+							Return(&cc, nil)
+						code.EXPECT().
+							GetFileContents(ctx, path).
+							Return([]byte(validStableReleaseChangelog), nil).Times(2)
+						repoClient.EXPECT().
+							FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+							Return("v0.5.0", nil)
+						code.EXPECT().
+							ListFiles(ctx, changelogutils.ChangelogDirectory).
+							Return([]os.FileInfo{getChangelogDir("v1.0.0")}, nil)
+						code.EXPECT().
+							ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, "v1.0.0")).
+							Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
+
+						file, err := validator.ValidateChangelog(ctx)
+						Expect(err).To(BeNil())
+						Expect(file).NotTo(BeNil())
+					})
+
+					It("errors when not incrementing for stable api release", func() {
+						path := filepath.Join(changelogutils.ChangelogDirectory, nextTag, filename1)
+						file1 := github.CommitFile{Filename: &path, Status: &added}
+						cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
+						repoClient.EXPECT().
+							CompareCommits(ctx, base, sha).
+							Return(&cc, nil)
+						code.EXPECT().
+							GetFileContents(ctx, path).
+							Return([]byte(validStableReleaseChangelog), nil).Times(2)
+						repoClient.EXPECT().
+							FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+							Return("v0.5.0", nil)
+						code.EXPECT().
+							ListFiles(ctx, changelogutils.ChangelogDirectory).
+							Return([]os.FileInfo{getChangelogDir(nextTag)}, nil)
+						code.EXPECT().
+							ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, nextTag)).
+							Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
+
+						expected := changelogutils.InvalidUseOfStableApiError(nextTag)
+						file, err := validator.ValidateChangelog(ctx)
+						Expect(err.Error()).To(Equal(expected.Error()))
+						Expect(file).To(BeNil())
+					})
+				})
+			})
+
+			Context("label workflow", func() {
+
+				labelWorkflow := func(lastTag, nextTag, contents string, settingsFunc func()) {
+					path := filepath.Join(changelogutils.ChangelogDirectory, nextTag, filename1)
+					file1 := github.CommitFile{Filename: &path, Status: &added}
+					cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
+					repoClient.EXPECT().
+						CompareCommits(ctx, base, sha).
+						Return(&cc, nil)
+					code.EXPECT().
+						GetFileContents(ctx, path).
+						Return([]byte(validBreakingChangelog), nil)
+					repoClient.EXPECT().
+						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+						Return(lastTag, nil)
+					code.EXPECT().
+						ListFiles(ctx, changelogutils.ChangelogDirectory).
+						Return([]os.FileInfo{getChangelogDir(nextTag)}, nil)
+					code.EXPECT().
+						ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, nextTag)).
+						Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
+					code.EXPECT().
+						GetFileContents(ctx, path).
+						Return([]byte(contents), nil)
+
+					settingsFunc()
+
+					file, err := validator.ValidateChangelog(ctx)
+					Expect(err).To(BeNil())
+					Expect(file).NotTo(BeNil())
+				}
+
+				DescribeTable("label workflow cases",
+					labelWorkflow,
+					Entry("initial rc", "v0.20.5", "v1.0.0-rc1", validBreakingChangelog, noValidationSettingsExist),
+					Entry("initial rc relaxed", "v0.20.5", "v1.0.0-rc1", validBreakingChangelog, relaxedValidationSettingsExists),
+					Entry("incrementing rc", "v1.0.0-rc1", "v1.0.0-rc2", validBreakingChangelog, noValidationSettingsExist),
+					Entry("incrementing rc relaxed", "v1.0.0-rc1", "v1.0.0-rc2", validBreakingChangelog, relaxedValidationSettingsExists),
+					Entry("stable release after rc for 1.0", "v1.0.0-rc2", "v1.0.0", validStableReleaseChangelog, noValidationSettingsExist),
+					Entry("stable release after rc for 1.0 relaxed", "v1.0.0-rc2", "v1.0.0", validStableReleaseChangelog, relaxedValidationSettingsExists),
+					Entry("stable release after rc for 1.1", "v1.1.0-rc2", "v1.1.0", validStableReleaseChangelog, noValidationSettingsExist),
+					Entry("stable release after rc for 1.1 relaxed", "v1.1.0-rc2", "v1.1.0", validStableReleaseChangelog, relaxedValidationSettingsExists),
+					Entry("initial rc after for 1.1", "v1.0.0", "v1.1.0-rc1", validNewFeatureChangelog, noValidationSettingsExist),
+					Entry("initial rc after for 1.1 relaxed", "v1.0.0", "v1.1.0-rc1", validNewFeatureChangelog, relaxedValidationSettingsExists),
+					Entry("foo3 to bar1", "v1.0.0-foo3", "v1.0.0-bar1", validNewFeatureChangelog, noValidationSettingsExist),
+					Entry("foo3 to bar1 relaxed", "v1.0.0-foo3", "v1.0.0-bar1", validNewFeatureChangelog, relaxedValidationSettingsExists),
+					Entry("foo1 to bar1", "v1.0.0-foo1", "v1.0.0-bar1", validNewFeatureChangelog, noValidationSettingsExist),
+					Entry("foo1 to bar1 relaxed", "v1.0.0-foo1", "v1.0.0-bar1", validNewFeatureChangelog, relaxedValidationSettingsExists),
+					Entry("foo1 to bar3", "v1.0.0-foo1", "v1.0.0-bar3", validNewFeatureChangelog, noValidationSettingsExist),
+					Entry("foo1 to bar3 relaxed", "v1.0.0-foo1", "v1.0.0-bar3", validNewFeatureChangelog, relaxedValidationSettingsExists),
+					Entry("foo1 to next minor", "v1.1.0-foo1", "v1.1.0", validNewFeatureChangelog, noValidationSettingsExist),
+					Entry("foo1 to next minor relaxed", "v1.1.0-foo1", "v1.1.0", validNewFeatureChangelog, relaxedValidationSettingsExists))
+			})
+
+			Context("settings with allowed labels", func() {
+
+				setup := func(setupTag string) {
+					path := filepath.Join(changelogutils.ChangelogDirectory, setupTag, filename1)
+					file1 := github.CommitFile{Filename: &path, Status: &added}
+					cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
+					repoClient.EXPECT().
+						CompareCommits(ctx, base, sha).
+						Return(&cc, nil)
+					code.EXPECT().
+						GetFileContents(ctx, path).
+						Return([]byte(validBreakingChangelog), nil).Times(2)
+					repoClient.EXPECT().
+						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+						Return("v0.5.0", nil)
+					code.EXPECT().
+						ListFiles(ctx, changelogutils.ChangelogDirectory).
+						Return([]os.FileInfo{getChangelogDir(setupTag)}, nil)
+					code.EXPECT().
+						ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, setupTag)).
+						Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
+				}
+
+				allowedLabelsSettingsExists := func() {
+					repoClient.EXPECT().FileExists(ctx, sha, changelogutils.GetValidationSettingsPath()).Return(true, nil)
+					code.EXPECT().GetFileContents(ctx, changelogutils.GetValidationSettingsPath()).Return([]byte(allowedLabelsYaml), nil)
+				}
+
+				It("accepts a label in allowed labels", func() {
+					setup("v0.5.1-beta1")
+					allowedLabelsSettingsExists()
+					file, err := validator.ValidateChangelog(ctx)
+					Expect(file).NotTo(BeNil())
+					Expect(err).To(BeNil())
+				})
+
+				It("rejects a label not in allowed labels", func() {
+					setup("v0.5.1-foo1")
+					allowedLabelsSettingsExists()
+					file, err := validator.ValidateChangelog(ctx)
+					Expect(file).To(BeNil())
+					Expect(err.Error()).To(Equal(changelogutils.InvalidLabelError("foo", []string{"beta", "rc"}).Error()))
+				})
+			})
+
+			Context("invalid settings", func() {
+
+				setup := func() {
+					file1 := github.CommitFile{Filename: &path1, Status: &added}
+					cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
+					repoClient.EXPECT().
+						CompareCommits(ctx, base, sha).
+						Return(&cc, nil)
+					code.EXPECT().
+						GetFileContents(ctx, path1).
+						Return([]byte(validBreakingChangelog), nil).Times(2)
+					repoClient.EXPECT().
+						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+						Return("v0.5.0", nil)
+					code.EXPECT().
+						ListFiles(ctx, changelogutils.ChangelogDirectory).
+						Return([]os.FileInfo{getChangelogDir(tag)}, nil)
+					code.EXPECT().
+						ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, tag)).
+						Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
+				}
+
+				It("propagates error if checking for validation.yaml existence fails", func() {
+					setup()
+					emptyErr := eris.Errorf("")
+					repoClient.EXPECT().
+						FileExists(ctx, sha, changelogutils.GetValidationSettingsPath()).
+						Return(false, emptyErr)
+					file, err := validator.ValidateChangelog(ctx)
+					Expect(file).To(BeNil())
+					Expect(err).NotTo(BeNil())
+					Expect(err.Error()).To(Equal(changelogutils.UnableToGetSettingsError(emptyErr).Error()))
+				})
+
+				It("propagates error if reading validation.yaml fails", func() {
+					setup()
+					emptyErr := eris.Errorf("")
+					repoClient.EXPECT().
+						FileExists(ctx, sha, changelogutils.GetValidationSettingsPath()).
+						Return(true, nil)
+					code.EXPECT().
+						GetFileContents(ctx, changelogutils.GetValidationSettingsPath()).
+						Return(nil, emptyErr)
+					file, err := validator.ValidateChangelog(ctx)
+					Expect(file).To(BeNil())
+					Expect(err).NotTo(BeNil())
+					Expect(err.Error()).To(Equal(changelogutils.UnableToGetSettingsError(emptyErr).Error()))
+				})
+
+				It("propagates error if marshalling validation.yaml fails", func() {
+					setup()
+					emptyErr := eris.Errorf("")
+					repoClient.EXPECT().
+						FileExists(ctx, sha, changelogutils.GetValidationSettingsPath()).
+						Return(true, nil)
+					code.EXPECT().
+						GetFileContents(ctx, changelogutils.GetValidationSettingsPath()).
+						Return([]byte("fakeyaml"), nil)
+					file, err := validator.ValidateChangelog(ctx)
+					Expect(file).To(BeNil())
+					Expect(err).NotTo(BeNil())
+					Expect(err.Error()).To(ContainSubstring(changelogutils.UnableToGetSettingsError(emptyErr).Error()))
+				})
+			})
+
+			Context("PR adding validation settings", func() {
+
+				It("properly ignores validation when computing new changelog files", func() {
+					relaxedValidationSettingsExists()
+					validationPath := changelogutils.GetValidationSettingsPath()
+					file1 := github.CommitFile{Filename: &path1, Status: &added}
+					file2 := github.CommitFile{Filename: &validationPath, Status: &added}
+					cc := github.CommitsComparison{Files: []*github.CommitFile{&file1, &file2}}
 					repoClient.EXPECT().
 						CompareCommits(ctx, base, sha).
 						Return(&cc, nil)
@@ -366,452 +817,6 @@ var _ = Describe("changelog validator utils", func() {
 					Expect(file).NotTo(BeNil())
 					Expect(err).To(BeNil())
 				})
-
-				It("errors when not incrementing major version", func() {
-					file1 := github.CommitFile{Filename: &path1, Status: &added}
-					cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
-					repoClient.EXPECT().
-						CompareCommits(ctx, base, sha).
-						Return(&cc, nil)
-					code.EXPECT().
-						GetFileContents(ctx, path1).
-						Return([]byte(validBreakingChangelog), nil).Times(2)
-					repoClient.EXPECT().
-						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-						Return("v0.5.0", nil)
-					code.EXPECT().
-						ListFiles(ctx, changelogutils.ChangelogDirectory).
-						Return([]os.FileInfo{getChangelogDir(tag)}, nil)
-					code.EXPECT().
-						ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, tag)).
-						Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
-
-					expected := changelogutils.UnexpectedProposedVersionError("v0.6.0", tag)
-					file, err := validator.ValidateChangelog(ctx)
-					Expect(file).To(BeNil())
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(Equal(expected.Error()))
-				})
-
-				It("works when incrementing major version", func() {
-					path := filepath.Join(changelogutils.ChangelogDirectory, "v0.6.0", filename1)
-					file1 := github.CommitFile{Filename: &path, Status: &added}
-					cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
-					repoClient.EXPECT().
-						CompareCommits(ctx, base, sha).
-						Return(&cc, nil)
-					code.EXPECT().
-						GetFileContents(ctx, path).
-						Return([]byte(validBreakingChangelog), nil).Times(2)
-					repoClient.EXPECT().
-						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-						Return("v0.5.0", nil)
-					code.EXPECT().
-						ListFiles(ctx, changelogutils.ChangelogDirectory).
-						Return([]os.FileInfo{getChangelogDir("v0.6.0")}, nil)
-					code.EXPECT().
-						ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, "v0.6.0")).
-						Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
-
-					file, err := validator.ValidateChangelog(ctx)
-					Expect(err).To(BeNil())
-					Expect(file).NotTo(BeNil())
-				})
-
-			})
-
-			Context("major version is 1.y.z", func() {
-
-				DescribeTable("correctly enforces version bump rules",
-					validateVersionBump,
-					Entry("breaking change with patch bump", "v1.0.0", "v1.0.1", validBreakingChangelog, true),
-					Entry("breaking change with minor bump", "v1.0.0", "v1.1.0", validBreakingChangelog, true),
-					Entry("breaking change with major bump", "v1.0.0", "v2.0.0", validBreakingChangelog, false),
-					Entry("new feature with patch bump", "v1.0.0", "v1.0.1", validNewFeatureChangelog, true),
-					Entry("new feature with minor bump", "v1.0.0", "v1.1.0", validNewFeatureChangelog, false),
-					Entry("new feature with major bump", "v1.0.0", "v2.0.0", validNewFeatureChangelog, true),
-					Entry("non-breaking with patch bump", "v1.0.0", "v1.0.1", validNonBreakingNorNewFeatureChangelog, false),
-					Entry("non-breaking with minor bump", "v1.0.0", "v1.1.0", validNonBreakingNorNewFeatureChangelog, true),
-					Entry("non-breaking with major bump", "v1.0.0", "v2.0.0", validNonBreakingNorNewFeatureChangelog, true),
-				)
-			})
-
-			Context("moving from 0.x to 1.x", func() {
-
-				It("works for stable api release", func() {
-					path := filepath.Join(changelogutils.ChangelogDirectory, "v1.0.0", filename1)
-					file1 := github.CommitFile{Filename: &path, Status: &added}
-					cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
-					repoClient.EXPECT().
-						CompareCommits(ctx, base, sha).
-						Return(&cc, nil)
-					code.EXPECT().
-						GetFileContents(ctx, path).
-						Return([]byte(validStableReleaseChangelog), nil).Times(2)
-					repoClient.EXPECT().
-						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-						Return("v0.5.0", nil)
-					code.EXPECT().
-						ListFiles(ctx, changelogutils.ChangelogDirectory).
-						Return([]os.FileInfo{getChangelogDir("v1.0.0")}, nil)
-					code.EXPECT().
-						ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, "v1.0.0")).
-						Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
-
-					file, err := validator.ValidateChangelog(ctx)
-					Expect(err).To(BeNil())
-					Expect(file).NotTo(BeNil())
-				})
-
-				It("errors when not incrementing for stable api release", func() {
-					path := filepath.Join(changelogutils.ChangelogDirectory, nextTag, filename1)
-					file1 := github.CommitFile{Filename: &path, Status: &added}
-					cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
-					repoClient.EXPECT().
-						CompareCommits(ctx, base, sha).
-						Return(&cc, nil)
-					code.EXPECT().
-						GetFileContents(ctx, path).
-						Return([]byte(validStableReleaseChangelog), nil).Times(2)
-					repoClient.EXPECT().
-						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-						Return("v0.5.0", nil)
-					code.EXPECT().
-						ListFiles(ctx, changelogutils.ChangelogDirectory).
-						Return([]os.FileInfo{getChangelogDir(nextTag)}, nil)
-					code.EXPECT().
-						ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, nextTag)).
-						Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
-
-					expected := changelogutils.InvalidUseOfStableApiError(nextTag)
-					file, err := validator.ValidateChangelog(ctx)
-					Expect(err.Error()).To(Equal(expected.Error()))
-					Expect(file).To(BeNil())
-				})
-			})
-		})
-
-		Context("incrementing versions with relaxed validation", func() {
-
-			BeforeEach(func() {
-				relaxedValidationSettingsExists()
-			})
-
-			Context("major version zero 0.y.z", func() {
-
-				It("allows not incrementing major version", func() {
-					file1 := github.CommitFile{Filename: &path1, Status: &added}
-					cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
-					repoClient.EXPECT().
-						CompareCommits(ctx, base, sha).
-						Return(&cc, nil)
-					code.EXPECT().
-						GetFileContents(ctx, path1).
-						Return([]byte(validBreakingChangelog), nil).Times(2)
-					repoClient.EXPECT().
-						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-						Return("v0.5.0", nil)
-					code.EXPECT().
-						ListFiles(ctx, changelogutils.ChangelogDirectory).
-						Return([]os.FileInfo{getChangelogDir(tag)}, nil)
-					code.EXPECT().
-						ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, tag)).
-						Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
-
-					file, err := validator.ValidateChangelog(ctx)
-					Expect(file).NotTo(BeNil())
-					Expect(err).To(BeNil())
-				})
-
-				It("works when incrementing major version", func() {
-					path := filepath.Join(changelogutils.ChangelogDirectory, "v0.6.0", filename1)
-					file1 := github.CommitFile{Filename: &path, Status: &added}
-					cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
-					repoClient.EXPECT().
-						CompareCommits(ctx, base, sha).
-						Return(&cc, nil)
-					code.EXPECT().
-						GetFileContents(ctx, path).
-						Return([]byte(validBreakingChangelog), nil).Times(2)
-					repoClient.EXPECT().
-						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-						Return("v0.5.0", nil)
-					code.EXPECT().
-						ListFiles(ctx, changelogutils.ChangelogDirectory).
-						Return([]os.FileInfo{getChangelogDir("v0.6.0")}, nil)
-					code.EXPECT().
-						ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, "v0.6.0")).
-						Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
-
-					file, err := validator.ValidateChangelog(ctx)
-					Expect(err).To(BeNil())
-					Expect(file).NotTo(BeNil())
-				})
-
-			})
-
-			Context("major version is 1.y.z", func() {
-
-				DescribeTable("doesn't enforce version bump rules",
-					validateVersionBump,
-					Entry("breaking change with patch bump", "v1.0.0", "v1.0.1", validBreakingChangelog, false),
-					Entry("breaking change with minor bump", "v1.0.0", "v1.1.0", validBreakingChangelog, false),
-					Entry("breaking change with major bump", "v1.0.0", "v2.0.0", validBreakingChangelog, false),
-					Entry("new feature with patch bump", "v1.0.0", "v1.0.1", validNewFeatureChangelog, false),
-					Entry("new feature with minor bump", "v1.0.0", "v1.1.0", validNewFeatureChangelog, false),
-					Entry("new feature with major bump", "v1.0.0", "v2.0.0", validNewFeatureChangelog, false),
-					Entry("non-breaking with patch bump", "v1.0.0", "v1.0.1", validNonBreakingNorNewFeatureChangelog, false),
-					Entry("non-breaking with minor bump", "v1.0.0", "v1.1.0", validNonBreakingNorNewFeatureChangelog, false),
-					Entry("non-breaking with major bump", "v1.0.0", "v2.0.0", validNonBreakingNorNewFeatureChangelog, false),
-					Entry("stable release that skips to a future version", "v1.0.0-rc6", "v1.2.0", validNonBreakingNorNewFeatureChangelog, false),
-				)
-			})
-
-			Context("moving from 0.x to 1.x", func() {
-
-				It("works for stable api release", func() {
-					path := filepath.Join(changelogutils.ChangelogDirectory, "v1.0.0", filename1)
-					file1 := github.CommitFile{Filename: &path, Status: &added}
-					cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
-					repoClient.EXPECT().
-						CompareCommits(ctx, base, sha).
-						Return(&cc, nil)
-					code.EXPECT().
-						GetFileContents(ctx, path).
-						Return([]byte(validStableReleaseChangelog), nil).Times(2)
-					repoClient.EXPECT().
-						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-						Return("v0.5.0", nil)
-					code.EXPECT().
-						ListFiles(ctx, changelogutils.ChangelogDirectory).
-						Return([]os.FileInfo{getChangelogDir("v1.0.0")}, nil)
-					code.EXPECT().
-						ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, "v1.0.0")).
-						Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
-
-					file, err := validator.ValidateChangelog(ctx)
-					Expect(err).To(BeNil())
-					Expect(file).NotTo(BeNil())
-				})
-
-				It("errors when not incrementing for stable api release", func() {
-					path := filepath.Join(changelogutils.ChangelogDirectory, nextTag, filename1)
-					file1 := github.CommitFile{Filename: &path, Status: &added}
-					cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
-					repoClient.EXPECT().
-						CompareCommits(ctx, base, sha).
-						Return(&cc, nil)
-					code.EXPECT().
-						GetFileContents(ctx, path).
-						Return([]byte(validStableReleaseChangelog), nil).Times(2)
-					repoClient.EXPECT().
-						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-						Return("v0.5.0", nil)
-					code.EXPECT().
-						ListFiles(ctx, changelogutils.ChangelogDirectory).
-						Return([]os.FileInfo{getChangelogDir(nextTag)}, nil)
-					code.EXPECT().
-						ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, nextTag)).
-						Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
-
-					expected := changelogutils.InvalidUseOfStableApiError(nextTag)
-					file, err := validator.ValidateChangelog(ctx)
-					Expect(err.Error()).To(Equal(expected.Error()))
-					Expect(file).To(BeNil())
-				})
-			})
-		})
-
-		Context("label workflow", func() {
-
-			labelWorkflow := func(lastTag, nextTag, contents string, settingsFunc func()) {
-				path := filepath.Join(changelogutils.ChangelogDirectory, nextTag, filename1)
-				file1 := github.CommitFile{Filename: &path, Status: &added}
-				cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
-				repoClient.EXPECT().
-					CompareCommits(ctx, base, sha).
-					Return(&cc, nil)
-				code.EXPECT().
-					GetFileContents(ctx, path).
-					Return([]byte(validBreakingChangelog), nil)
-				repoClient.EXPECT().
-					FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-					Return(lastTag, nil)
-				code.EXPECT().
-					ListFiles(ctx, changelogutils.ChangelogDirectory).
-					Return([]os.FileInfo{getChangelogDir(nextTag)}, nil)
-				code.EXPECT().
-					ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, nextTag)).
-					Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
-				code.EXPECT().
-					GetFileContents(ctx, path).
-					Return([]byte(contents), nil)
-
-				settingsFunc()
-
-				file, err := validator.ValidateChangelog(ctx)
-				Expect(err).To(BeNil())
-				Expect(file).NotTo(BeNil())
-			}
-
-			DescribeTable("label workflow cases",
-				labelWorkflow,
-				Entry("initial rc", "v0.20.5", "v1.0.0-rc1", validBreakingChangelog, noValidationSettingsExist),
-				Entry("initial rc relaxed", "v0.20.5", "v1.0.0-rc1", validBreakingChangelog, relaxedValidationSettingsExists),
-				Entry("incrementing rc", "v1.0.0-rc1", "v1.0.0-rc2", validBreakingChangelog, noValidationSettingsExist),
-				Entry("incrementing rc relaxed", "v1.0.0-rc1", "v1.0.0-rc2", validBreakingChangelog, relaxedValidationSettingsExists),
-				Entry("stable release after rc for 1.0", "v1.0.0-rc2", "v1.0.0", validStableReleaseChangelog, noValidationSettingsExist),
-				Entry("stable release after rc for 1.0 relaxed", "v1.0.0-rc2", "v1.0.0", validStableReleaseChangelog, relaxedValidationSettingsExists),
-				Entry("stable release after rc for 1.1", "v1.1.0-rc2", "v1.1.0", validStableReleaseChangelog, noValidationSettingsExist),
-				Entry("stable release after rc for 1.1 relaxed", "v1.1.0-rc2", "v1.1.0", validStableReleaseChangelog, relaxedValidationSettingsExists),
-				Entry("initial rc after for 1.1", "v1.0.0", "v1.1.0-rc1", validNewFeatureChangelog, noValidationSettingsExist),
-				Entry("initial rc after for 1.1 relaxed", "v1.0.0", "v1.1.0-rc1", validNewFeatureChangelog, relaxedValidationSettingsExists),
-				Entry("foo3 to bar1", "v1.0.0-foo3", "v1.0.0-bar1", validNewFeatureChangelog, noValidationSettingsExist),
-				Entry("foo3 to bar1 relaxed", "v1.0.0-foo3", "v1.0.0-bar1", validNewFeatureChangelog, relaxedValidationSettingsExists),
-				Entry("foo1 to bar1", "v1.0.0-foo1", "v1.0.0-bar1", validNewFeatureChangelog, noValidationSettingsExist),
-				Entry("foo1 to bar1 relaxed", "v1.0.0-foo1", "v1.0.0-bar1", validNewFeatureChangelog, relaxedValidationSettingsExists),
-				Entry("foo1 to bar3", "v1.0.0-foo1", "v1.0.0-bar3", validNewFeatureChangelog, noValidationSettingsExist),
-				Entry("foo1 to bar3 relaxed", "v1.0.0-foo1", "v1.0.0-bar3", validNewFeatureChangelog, relaxedValidationSettingsExists),
-				Entry("foo1 to next minor", "v1.1.0-foo1", "v1.1.0", validNewFeatureChangelog, noValidationSettingsExist),
-				Entry("foo1 to next minor relaxed", "v1.1.0-foo1", "v1.1.0", validNewFeatureChangelog, relaxedValidationSettingsExists))
-		})
-
-		Context("settings with allowed labels", func() {
-
-			setup := func(setupTag string) {
-				path := filepath.Join(changelogutils.ChangelogDirectory, setupTag, filename1)
-				file1 := github.CommitFile{Filename: &path, Status: &added}
-				cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
-				repoClient.EXPECT().
-					CompareCommits(ctx, base, sha).
-					Return(&cc, nil)
-				code.EXPECT().
-					GetFileContents(ctx, path).
-					Return([]byte(validBreakingChangelog), nil).Times(2)
-				repoClient.EXPECT().
-					FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-					Return("v0.5.0", nil)
-				code.EXPECT().
-					ListFiles(ctx, changelogutils.ChangelogDirectory).
-					Return([]os.FileInfo{getChangelogDir(setupTag)}, nil)
-				code.EXPECT().
-					ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, setupTag)).
-					Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
-			}
-
-			allowedLabelsSettingsExists := func() {
-				repoClient.EXPECT().FileExists(ctx, sha, changelogutils.GetValidationSettingsPath()).Return(true, nil)
-				code.EXPECT().GetFileContents(ctx, changelogutils.GetValidationSettingsPath()).Return([]byte(allowedLabelsYaml), nil)
-			}
-
-			It("accepts a label in allowed labels", func() {
-				setup("v0.5.1-beta1")
-				allowedLabelsSettingsExists()
-				file, err := validator.ValidateChangelog(ctx)
-				Expect(file).NotTo(BeNil())
-				Expect(err).To(BeNil())
-			})
-
-			It("rejects a label not in allowed labels", func() {
-				setup("v0.5.1-foo1")
-				allowedLabelsSettingsExists()
-				file, err := validator.ValidateChangelog(ctx)
-				Expect(file).To(BeNil())
-				Expect(err.Error()).To(Equal(changelogutils.InvalidLabelError("foo", []string{"beta", "rc"}).Error()))
-			})
-		})
-
-		Context("invalid settings", func() {
-
-			setup := func() {
-				file1 := github.CommitFile{Filename: &path1, Status: &added}
-				cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
-				repoClient.EXPECT().
-					CompareCommits(ctx, base, sha).
-					Return(&cc, nil)
-				code.EXPECT().
-					GetFileContents(ctx, path1).
-					Return([]byte(validBreakingChangelog), nil).Times(2)
-				repoClient.EXPECT().
-					FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-					Return("v0.5.0", nil)
-				code.EXPECT().
-					ListFiles(ctx, changelogutils.ChangelogDirectory).
-					Return([]os.FileInfo{getChangelogDir(tag)}, nil)
-				code.EXPECT().
-					ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, tag)).
-					Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
-			}
-
-			It("propagates error if checking for validation.yaml existence fails", func() {
-				setup()
-				emptyErr := eris.Errorf("")
-				repoClient.EXPECT().
-					FileExists(ctx, sha, changelogutils.GetValidationSettingsPath()).
-					Return(false, emptyErr)
-				file, err := validator.ValidateChangelog(ctx)
-				Expect(file).To(BeNil())
-				Expect(err).NotTo(BeNil())
-				Expect(err.Error()).To(Equal(changelogutils.UnableToGetSettingsError(emptyErr).Error()))
-			})
-
-			It("propagates error if reading validation.yaml fails", func() {
-				setup()
-				emptyErr := eris.Errorf("")
-				repoClient.EXPECT().
-					FileExists(ctx, sha, changelogutils.GetValidationSettingsPath()).
-					Return(true, nil)
-				code.EXPECT().
-					GetFileContents(ctx, changelogutils.GetValidationSettingsPath()).
-					Return(nil, emptyErr)
-				file, err := validator.ValidateChangelog(ctx)
-				Expect(file).To(BeNil())
-				Expect(err).NotTo(BeNil())
-				Expect(err.Error()).To(Equal(changelogutils.UnableToGetSettingsError(emptyErr).Error()))
-			})
-
-			It("propagates error if marshalling validation.yaml fails", func() {
-				setup()
-				emptyErr := eris.Errorf("")
-				repoClient.EXPECT().
-					FileExists(ctx, sha, changelogutils.GetValidationSettingsPath()).
-					Return(true, nil)
-				code.EXPECT().
-					GetFileContents(ctx, changelogutils.GetValidationSettingsPath()).
-					Return([]byte("fakeyaml"), nil)
-				file, err := validator.ValidateChangelog(ctx)
-				Expect(file).To(BeNil())
-				Expect(err).NotTo(BeNil())
-				Expect(err.Error()).To(ContainSubstring(changelogutils.UnableToGetSettingsError(emptyErr).Error()))
-			})
-		})
-
-		Context("PR adding validation settings", func() {
-
-			It("properly ignores validation when computing new changelog files", func() {
-				relaxedValidationSettingsExists()
-				validationPath := changelogutils.GetValidationSettingsPath()
-				file1 := github.CommitFile{Filename: &path1, Status: &added}
-				file2 := github.CommitFile{Filename: &validationPath, Status: &added}
-				cc := github.CommitsComparison{Files: []*github.CommitFile{&file1, &file2}}
-				repoClient.EXPECT().
-					CompareCommits(ctx, base, sha).
-					Return(&cc, nil)
-				code.EXPECT().
-					GetFileContents(ctx, path1).
-					Return([]byte(validChangelog1), nil).Times(2)
-				repoClient.EXPECT().
-					FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-					Return("v0.5.0", nil)
-				code.EXPECT().
-					ListFiles(ctx, changelogutils.ChangelogDirectory).
-					Return([]os.FileInfo{getChangelogDir(tag)}, nil)
-				code.EXPECT().
-					ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, tag)).
-					Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
-				file, err := validator.ValidateChangelog(ctx)
-				Expect(file).NotTo(BeNil())
-				Expect(err).To(BeNil())
 			})
 		})
 	})

--- a/changelogutils/validator_test.go
+++ b/changelogutils/validator_test.go
@@ -36,193 +36,205 @@ var _ = Describe("changelog validator utils", func() {
 		ctrl = gomock.NewController(test)
 		code = NewMockMountedRepo(ctrl)
 		repoClient = NewMockRepoClient(ctrl)
+		validator = changelogutils.NewChangelogValidator(repoClient, code, base)
 	})
 
 	AfterEach(func() {
 		ctrl.Finish()
 	})
 
-	Context("With default tag validator", func() {
+	Context("should check changelog", func() {
+		It("should check if master has changelog", func() {
+			repoClient.EXPECT().
+				DirectoryExists(ctx, changelogutils.MasterBranch, changelogutils.ChangelogDirectory).
+				Return(true, nil)
+
+			check, err := validator.ShouldCheckChangelog(ctx)
+			Expect(err).To(BeNil())
+			Expect(check).To(BeTrue())
+		})
+
+		It("should not check if error looking at master", func() {
+			repoClient.EXPECT().
+				DirectoryExists(ctx, changelogutils.MasterBranch, changelogutils.ChangelogDirectory).
+				Return(false, nestedErr)
+
+			check, err := validator.ShouldCheckChangelog(ctx)
+			Expect(err).To(Equal(nestedErr))
+			Expect(check).To(BeFalse())
+		})
+
+		It("should check if sha has changelog but master doesn't", func() {
+			repoClient.EXPECT().
+				DirectoryExists(ctx, changelogutils.MasterBranch, changelogutils.ChangelogDirectory).
+				Return(false, nil)
+			code.EXPECT().GetSha().Return(sha)
+			repoClient.EXPECT().
+				DirectoryExists(ctx, sha, changelogutils.ChangelogDirectory).
+				Return(true, nil)
+
+			check, err := validator.ShouldCheckChangelog(ctx)
+			Expect(err).To(BeNil())
+			Expect(check).To(BeTrue())
+		})
+
+		It("shouldn't check if sha and master don't have changelog", func() {
+			repoClient.EXPECT().
+				DirectoryExists(ctx, changelogutils.MasterBranch, changelogutils.ChangelogDirectory).
+				Return(false, nil)
+			code.EXPECT().GetSha().Return(sha)
+			repoClient.EXPECT().
+				DirectoryExists(ctx, sha, changelogutils.ChangelogDirectory).
+				Return(false, nil)
+
+			check, err := validator.ShouldCheckChangelog(ctx)
+			Expect(err).To(BeNil())
+			Expect(check).To(BeFalse())
+		})
+
+		It("shouldn't check if error looking at sha", func() {
+			repoClient.EXPECT().
+				DirectoryExists(ctx, changelogutils.MasterBranch, changelogutils.ChangelogDirectory).
+				Return(false, nil)
+			code.EXPECT().GetSha().Return(sha)
+			repoClient.EXPECT().
+				DirectoryExists(ctx, sha, changelogutils.ChangelogDirectory).
+				Return(false, nestedErr)
+
+			check, err := validator.ShouldCheckChangelog(ctx)
+			Expect(err).To(Equal(nestedErr))
+			Expect(check).To(BeFalse())
+		})
+	})
+
+	Context("validate changelog", func() {
+
+		const (
+			filename1 = "1.yaml"
+			filename2 = "2.yaml"
+			filename3 = "3.yaml"
+			tag       = "v0.5.1"
+			nextTag   = "v0.5.2"
+		)
+
+		var (
+			path1          = filepath.Join(changelogutils.ChangelogDirectory, tag, filename1)
+			path2          = filepath.Join(changelogutils.ChangelogDirectory, tag, filename2)
+			added          = githubutils.COMMIT_FILE_STATUS_ADDED
+			unexpectedFile = mockFileInfo{isDir: false, name: "unexpected"}
+
+			path3 = filepath.Join(changelogutils.ChangelogDirectory, nextTag, filename3)
+		)
+
+		relaxedValidationSettingsExists := func() {
+			repoClient.EXPECT().FileExists(ctx, sha, changelogutils.GetValidationSettingsPath()).Return(true, nil)
+			code.EXPECT().GetFileContents(ctx, changelogutils.GetValidationSettingsPath()).Return([]byte(validationYaml), nil)
+		}
+
+		noValidationSettingsExist := func() {
+			repoClient.EXPECT().FileExists(ctx, sha, changelogutils.GetValidationSettingsPath()).Return(false, nil)
+		}
+
+		getChangelogDir := func(tag string) os.FileInfo {
+			return &mockFileInfo{name: tag, isDir: true}
+		}
+
+		validateVersionBump := func(lastTag, nextTag, contents string, expectFailure bool) {
+
+			nextTagFile := filepath.Join(changelogutils.ChangelogDirectory, nextTag, filename1)
+			cc := github.CommitsComparison{Files: []*github.CommitFile{{Filename: &nextTagFile, Status: &added}}}
+
+			repoClient.EXPECT().
+				CompareCommits(ctx, base, sha).
+				Return(&cc, nil)
+
+			code.EXPECT().
+				GetFileContents(ctx, nextTagFile).
+				Return([]byte(contents), nil).Times(2)
+
+			repoClient.EXPECT().
+				FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+				Return(lastTag, nil)
+
+			code.EXPECT().
+				ListFiles(ctx, changelogutils.ChangelogDirectory).
+				Return([]os.FileInfo{getChangelogDir(nextTag)}, nil)
+
+			code.EXPECT().
+				ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, nextTag)).
+				Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
+
+			file, err := validator.ValidateChangelog(ctx)
+
+			if expectFailure {
+				Expect(err).To(HaveOccurred())
+				Expect(file).To(BeNil())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(file).NotTo(BeNil())
+			}
+		}
+
 		BeforeEach(func() {
-			validator = changelogutils.NewChangelogValidator(repoClient, code, base)
+			// so should check returns true
+			repoClient.EXPECT().
+				DirectoryExists(ctx, changelogutils.MasterBranch, changelogutils.ChangelogDirectory).
+				Return(true, nil)
+			code.EXPECT().GetSha().Return(sha).AnyTimes()
 		})
 
-		Context("should check changelog", func() {
-			It("should check if master has changelog", func() {
-				repoClient.EXPECT().
-					DirectoryExists(ctx, changelogutils.MasterBranch, changelogutils.ChangelogDirectory).
-					Return(true, nil)
-
-				check, err := validator.ShouldCheckChangelog(ctx)
-				Expect(err).To(BeNil())
-				Expect(check).To(BeTrue())
-			})
-
-			It("should not check if error looking at master", func() {
-				repoClient.EXPECT().
-					DirectoryExists(ctx, changelogutils.MasterBranch, changelogutils.ChangelogDirectory).
-					Return(false, nestedErr)
-
-				check, err := validator.ShouldCheckChangelog(ctx)
-				Expect(err).To(Equal(nestedErr))
-				Expect(check).To(BeFalse())
-			})
-
-			It("should check if sha has changelog but master doesn't", func() {
-				repoClient.EXPECT().
-					DirectoryExists(ctx, changelogutils.MasterBranch, changelogutils.ChangelogDirectory).
-					Return(false, nil)
-				code.EXPECT().GetSha().Return(sha)
-				repoClient.EXPECT().
-					DirectoryExists(ctx, sha, changelogutils.ChangelogDirectory).
-					Return(true, nil)
-
-				check, err := validator.ShouldCheckChangelog(ctx)
-				Expect(err).To(BeNil())
-				Expect(check).To(BeTrue())
-			})
-
-			It("shouldn't check if sha and master don't have changelog", func() {
-				repoClient.EXPECT().
-					DirectoryExists(ctx, changelogutils.MasterBranch, changelogutils.ChangelogDirectory).
-					Return(false, nil)
-				code.EXPECT().GetSha().Return(sha)
-				repoClient.EXPECT().
-					DirectoryExists(ctx, sha, changelogutils.ChangelogDirectory).
-					Return(false, nil)
-
-				check, err := validator.ShouldCheckChangelog(ctx)
-				Expect(err).To(BeNil())
-				Expect(check).To(BeFalse())
-			})
-
-			It("shouldn't check if error looking at sha", func() {
-				repoClient.EXPECT().
-					DirectoryExists(ctx, changelogutils.MasterBranch, changelogutils.ChangelogDirectory).
-					Return(false, nil)
-				code.EXPECT().GetSha().Return(sha)
-				repoClient.EXPECT().
-					DirectoryExists(ctx, sha, changelogutils.ChangelogDirectory).
-					Return(false, nestedErr)
-
-				check, err := validator.ShouldCheckChangelog(ctx)
-				Expect(err).To(Equal(nestedErr))
-				Expect(check).To(BeFalse())
-			})
+		It("propagates error comparing commits", func() {
+			repoClient.EXPECT().
+				CompareCommits(ctx, base, sha).
+				Return(nil, nestedErr)
+			file, err := validator.ValidateChangelog(ctx)
+			Expect(file).To(BeNil())
+			Expect(err).To(Equal(nestedErr))
 		})
 
-		Context("validate changelog", func() {
+		It("errors when no changelog file added", func() {
+			cc := github.CommitsComparison{}
+			repoClient.EXPECT().
+				CompareCommits(ctx, base, sha).
+				Return(&cc, nil)
 
-			const (
-				filename1 = "1.yaml"
-				filename2 = "2.yaml"
-				filename3 = "3.yaml"
-				tag       = "v0.5.1"
-				nextTag   = "v0.5.2"
-			)
+			expected := changelogutils.NoChangelogFileAddedError
+			file, err := validator.ValidateChangelog(ctx)
+			Expect(file).To(BeNil())
+			Expect(err).To(Equal(expected))
+		})
 
-			var (
-				path1          = filepath.Join(changelogutils.ChangelogDirectory, tag, filename1)
-				path2          = filepath.Join(changelogutils.ChangelogDirectory, tag, filename2)
-				added          = githubutils.COMMIT_FILE_STATUS_ADDED
-				unexpectedFile = mockFileInfo{isDir: false, name: "unexpected"}
+		It("errors when more than one changelog file added", func() {
+			file1 := github.CommitFile{Filename: &path1, Status: &added}
+			file2 := github.CommitFile{Filename: &path2, Status: &added}
+			cc := github.CommitsComparison{Files: []*github.CommitFile{&file1, &file2}}
+			repoClient.EXPECT().
+				CompareCommits(ctx, base, sha).
+				Return(&cc, nil)
 
-				path3 = filepath.Join(changelogutils.ChangelogDirectory, nextTag, filename3)
-			)
+			expected := changelogutils.TooManyChangelogFilesAddedError(2)
+			file, err := validator.ValidateChangelog(ctx)
+			Expect(file).To(BeNil())
+			Expect(err.Error()).To(Equal(expected.Error()))
+		})
 
-			relaxedValidationSettingsExists := func() {
-				repoClient.EXPECT().FileExists(ctx, sha, changelogutils.GetValidationSettingsPath()).Return(true, nil)
-				code.EXPECT().GetFileContents(ctx, changelogutils.GetValidationSettingsPath()).Return([]byte(validationYaml), nil)
-			}
+		It("errors when getting changelog file contents fails", func() {
+			file1 := github.CommitFile{Filename: &path1, Status: &added}
+			cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
+			repoClient.EXPECT().
+				CompareCommits(ctx, base, sha).
+				Return(&cc, nil)
+			code.EXPECT().
+				GetFileContents(ctx, path1).
+				Return(nil, nestedErr)
 
-			noValidationSettingsExist := func() {
-				repoClient.EXPECT().FileExists(ctx, sha, changelogutils.GetValidationSettingsPath()).Return(false, nil)
-			}
+			file, err := validator.ValidateChangelog(ctx)
+			Expect(file).To(BeNil())
+			Expect(err).To(Equal(nestedErr))
+		})
 
-			getChangelogDir := func(tag string) os.FileInfo {
-				return &mockFileInfo{name: tag, isDir: true}
-			}
-
-			validateVersionBump := func(lastTag, nextTag, contents string, expectFailure bool) {
-
-				nextTagFile := filepath.Join(changelogutils.ChangelogDirectory, nextTag, filename1)
-				cc := github.CommitsComparison{Files: []*github.CommitFile{{Filename: &nextTagFile, Status: &added}}}
-
-				repoClient.EXPECT().
-					CompareCommits(ctx, base, sha).
-					Return(&cc, nil)
-
-				code.EXPECT().
-					GetFileContents(ctx, nextTagFile).
-					Return([]byte(contents), nil).Times(2)
-
-				repoClient.EXPECT().
-					FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-					Return(lastTag, nil)
-
-				code.EXPECT().
-					ListFiles(ctx, changelogutils.ChangelogDirectory).
-					Return([]os.FileInfo{getChangelogDir(nextTag)}, nil)
-
-				code.EXPECT().
-					ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, nextTag)).
-					Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
-
-				file, err := validator.ValidateChangelog(ctx)
-
-				if expectFailure {
-					Expect(err).To(HaveOccurred())
-					Expect(file).To(BeNil())
-				} else {
-					Expect(err).NotTo(HaveOccurred())
-					Expect(file).NotTo(BeNil())
-				}
-			}
-
+		Context("validating proposed tag", func() {
 			BeforeEach(func() {
-				// so should check returns true
-				repoClient.EXPECT().
-					DirectoryExists(ctx, changelogutils.MasterBranch, changelogutils.ChangelogDirectory).
-					Return(true, nil)
-				code.EXPECT().GetSha().Return(sha).AnyTimes()
-			})
-
-			It("propagates error comparing commits", func() {
-				repoClient.EXPECT().
-					CompareCommits(ctx, base, sha).
-					Return(nil, nestedErr)
-				file, err := validator.ValidateChangelog(ctx)
-				Expect(file).To(BeNil())
-				Expect(err).To(Equal(nestedErr))
-			})
-
-			It("errors when no changelog file added", func() {
-				cc := github.CommitsComparison{}
-				repoClient.EXPECT().
-					CompareCommits(ctx, base, sha).
-					Return(&cc, nil)
-
-				expected := changelogutils.NoChangelogFileAddedError
-				file, err := validator.ValidateChangelog(ctx)
-				Expect(file).To(BeNil())
-				Expect(err).To(Equal(expected))
-			})
-
-			It("errors when more than one changelog file added", func() {
-				file1 := github.CommitFile{Filename: &path1, Status: &added}
-				file2 := github.CommitFile{Filename: &path2, Status: &added}
-				cc := github.CommitsComparison{Files: []*github.CommitFile{&file1, &file2}}
-				repoClient.EXPECT().
-					CompareCommits(ctx, base, sha).
-					Return(&cc, nil)
-
-				expected := changelogutils.TooManyChangelogFilesAddedError(2)
-				file, err := validator.ValidateChangelog(ctx)
-				Expect(file).To(BeNil())
-				Expect(err.Error()).To(Equal(expected.Error()))
-			})
-
-			It("errors when getting changelog file contents fails", func() {
 				file1 := github.CommitFile{Filename: &path1, Status: &added}
 				cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
 				repoClient.EXPECT().
@@ -230,574 +242,111 @@ var _ = Describe("changelog validator utils", func() {
 					Return(&cc, nil)
 				code.EXPECT().
 					GetFileContents(ctx, path1).
-					Return(nil, nestedErr)
+					Return([]byte(validChangelog1), nil)
+			})
 
+			It("propagates error listing releases", func() {
+				repoClient.EXPECT().
+					FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+					Return("", nestedErr)
+
+				expected := changelogutils.ListReleasesError(nestedErr)
 				file, err := validator.ValidateChangelog(ctx)
 				Expect(file).To(BeNil())
-				Expect(err).To(Equal(nestedErr))
+				Expect(err.Error()).To(Equal(expected.Error()))
 			})
 
-			Context("validating proposed tag", func() {
-				BeforeEach(func() {
+			It("errors when unexpected file in changelog directory", func() {
+				repoClient.EXPECT().
+					FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+					Return(tag, nil)
+				code.EXPECT().
+					ListFiles(ctx, changelogutils.ChangelogDirectory).
+					Return([]os.FileInfo{&unexpectedFile}, nil)
+
+				expected := changelogutils.UnexpectedFileInChangelogDirectoryError(unexpectedFile.name)
+				file, err := validator.ValidateChangelog(ctx)
+				Expect(file).To(BeNil())
+				Expect(err.Error()).To(Equal(expected.Error()))
+			})
+
+			It("errors when invalid tag in changelog directory", func() {
+				repoClient.EXPECT().
+					FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+					Return(tag, nil)
+				code.EXPECT().
+					ListFiles(ctx, changelogutils.ChangelogDirectory).
+					Return([]os.FileInfo{getChangelogDir("invalid-tag")}, nil)
+
+				expected := changelogutils.InvalidChangelogSubdirectoryNameError("invalid-tag")
+				file, err := validator.ValidateChangelog(ctx)
+				Expect(file).To(BeNil())
+				Expect(err.Error()).To(Equal(expected.Error()))
+			})
+
+			It("errors when no new version", func() {
+				repoClient.EXPECT().
+					FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+					Return(tag, nil)
+				code.EXPECT().
+					ListFiles(ctx, changelogutils.ChangelogDirectory).
+					Return([]os.FileInfo{getChangelogDir(tag)}, nil)
+
+				expected := changelogutils.NoNewVersionsFoundError(tag)
+				file, err := validator.ValidateChangelog(ctx)
+				Expect(file).To(BeNil())
+				Expect(err.Error()).To(Equal(expected.Error()))
+			})
+
+			It("errors when no too many new versions", func() {
+				repoClient.EXPECT().
+					FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+					Return(tag, nil)
+				code.EXPECT().
+					ListFiles(ctx, changelogutils.ChangelogDirectory).
+					Return([]os.FileInfo{getChangelogDir("v0.5.2"), getChangelogDir("v0.5.3")}, nil)
+
+				expected := changelogutils.MultipleNewVersionsFoundError(tag, "v0.5.2", "v0.5.3")
+				file, err := validator.ValidateChangelog(ctx)
+				Expect(file).To(BeNil())
+				Expect(err.Error()).To(Equal(expected.Error()))
+			})
+
+			It("errors when added changelog to old version", func() {
+				repoClient.EXPECT().
+					FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+					Return(tag, nil)
+				code.EXPECT().
+					ListFiles(ctx, changelogutils.ChangelogDirectory).
+					Return([]os.FileInfo{getChangelogDir(nextTag)}, nil)
+				code.EXPECT().
+					ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, nextTag)).
+					Return([]os.FileInfo{&mockFileInfo{name: filename3, isDir: false}}, nil)
+				code.EXPECT().
+					GetFileContents(ctx, path3).
+					Return([]byte(validChangelog2), nil)
+				repoClient.EXPECT().
+					FileExists(ctx, sha, changelogutils.GetValidationSettingsPath()).
+					Return(false, nil)
+				expected := changelogutils.AddedChangelogInOldVersionError(nextTag)
+				file, err := validator.ValidateChangelog(ctx)
+				Expect(file).To(BeNil())
+				Expect(err.Error()).To(Equal(expected.Error()))
+			})
+
+		})
+
+		Context("incrementing versions", func() {
+
+			BeforeEach(func() {
+				noValidationSettingsExist()
+			})
+
+			Context("major version zero 0.y.z", func() {
+
+				It("works on patch version bump", func() {
 					file1 := github.CommitFile{Filename: &path1, Status: &added}
 					cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
-					repoClient.EXPECT().
-						CompareCommits(ctx, base, sha).
-						Return(&cc, nil)
-					code.EXPECT().
-						GetFileContents(ctx, path1).
-						Return([]byte(validChangelog1), nil)
-				})
-
-				It("propagates error listing releases", func() {
-					repoClient.EXPECT().
-						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-						Return("", nestedErr)
-
-					expected := changelogutils.ListReleasesError(nestedErr)
-					file, err := validator.ValidateChangelog(ctx)
-					Expect(file).To(BeNil())
-					Expect(err.Error()).To(Equal(expected.Error()))
-				})
-
-				It("errors when unexpected file in changelog directory", func() {
-					repoClient.EXPECT().
-						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-						Return(tag, nil)
-					code.EXPECT().
-						ListFiles(ctx, changelogutils.ChangelogDirectory).
-						Return([]os.FileInfo{&unexpectedFile}, nil)
-
-					expected := changelogutils.UnexpectedFileInChangelogDirectoryError(unexpectedFile.name)
-					file, err := validator.ValidateChangelog(ctx)
-					Expect(file).To(BeNil())
-					Expect(err.Error()).To(Equal(expected.Error()))
-				})
-
-				It("errors when invalid tag in changelog directory", func() {
-					repoClient.EXPECT().
-						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-						Return(tag, nil)
-					code.EXPECT().
-						ListFiles(ctx, changelogutils.ChangelogDirectory).
-						Return([]os.FileInfo{getChangelogDir("invalid-tag")}, nil)
-
-					expected := changelogutils.InvalidChangelogSubdirectoryNameError("invalid-tag")
-					file, err := validator.ValidateChangelog(ctx)
-					Expect(file).To(BeNil())
-					Expect(err.Error()).To(Equal(expected.Error()))
-				})
-
-				It("errors when no new version", func() {
-					repoClient.EXPECT().
-						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-						Return(tag, nil)
-					code.EXPECT().
-						ListFiles(ctx, changelogutils.ChangelogDirectory).
-						Return([]os.FileInfo{getChangelogDir(tag)}, nil)
-
-					expected := changelogutils.NoNewVersionsFoundError(tag)
-					file, err := validator.ValidateChangelog(ctx)
-					Expect(file).To(BeNil())
-					Expect(err.Error()).To(Equal(expected.Error()))
-				})
-
-				It("errors when no too many new versions", func() {
-					repoClient.EXPECT().
-						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-						Return(tag, nil)
-					code.EXPECT().
-						ListFiles(ctx, changelogutils.ChangelogDirectory).
-						Return([]os.FileInfo{getChangelogDir("v0.5.2"), getChangelogDir("v0.5.3")}, nil)
-
-					expected := changelogutils.MultipleNewVersionsFoundError(tag, "v0.5.2", "v0.5.3")
-					file, err := validator.ValidateChangelog(ctx)
-					Expect(file).To(BeNil())
-					Expect(err.Error()).To(Equal(expected.Error()))
-				})
-
-				It("errors when added changelog to old version", func() {
-					repoClient.EXPECT().
-						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-						Return(tag, nil)
-					code.EXPECT().
-						ListFiles(ctx, changelogutils.ChangelogDirectory).
-						Return([]os.FileInfo{getChangelogDir(nextTag)}, nil)
-					code.EXPECT().
-						ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, nextTag)).
-						Return([]os.FileInfo{&mockFileInfo{name: filename3, isDir: false}}, nil)
-					code.EXPECT().
-						GetFileContents(ctx, path3).
-						Return([]byte(validChangelog2), nil)
-					repoClient.EXPECT().
-						FileExists(ctx, sha, changelogutils.GetValidationSettingsPath()).
-						Return(false, nil)
-					expected := changelogutils.AddedChangelogInOldVersionError(nextTag)
-					file, err := validator.ValidateChangelog(ctx)
-					Expect(file).To(BeNil())
-					Expect(err.Error()).To(Equal(expected.Error()))
-				})
-
-			})
-
-			Context("incrementing versions", func() {
-
-				BeforeEach(func() {
-					noValidationSettingsExist()
-				})
-
-				Context("major version zero 0.y.z", func() {
-
-					It("works on patch version bump", func() {
-						file1 := github.CommitFile{Filename: &path1, Status: &added}
-						cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
-						repoClient.EXPECT().
-							CompareCommits(ctx, base, sha).
-							Return(&cc, nil)
-						code.EXPECT().
-							GetFileContents(ctx, path1).
-							Return([]byte(validChangelog1), nil).Times(2)
-						repoClient.EXPECT().
-							FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-							Return("v0.5.0", nil)
-						code.EXPECT().
-							ListFiles(ctx, changelogutils.ChangelogDirectory).
-							Return([]os.FileInfo{getChangelogDir(tag)}, nil)
-						code.EXPECT().
-							ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, tag)).
-							Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
-						file, err := validator.ValidateChangelog(ctx)
-						Expect(file).NotTo(BeNil())
-						Expect(err).To(BeNil())
-					})
-
-					It("errors when not incrementing major version", func() {
-						file1 := github.CommitFile{Filename: &path1, Status: &added}
-						cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
-						repoClient.EXPECT().
-							CompareCommits(ctx, base, sha).
-							Return(&cc, nil)
-						code.EXPECT().
-							GetFileContents(ctx, path1).
-							Return([]byte(validBreakingChangelog), nil).Times(2)
-						repoClient.EXPECT().
-							FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-							Return("v0.5.0", nil)
-						code.EXPECT().
-							ListFiles(ctx, changelogutils.ChangelogDirectory).
-							Return([]os.FileInfo{getChangelogDir(tag)}, nil)
-						code.EXPECT().
-							ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, tag)).
-							Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
-
-						expected := changelogutils.UnexpectedProposedVersionError("v0.6.0", tag)
-						file, err := validator.ValidateChangelog(ctx)
-						Expect(file).To(BeNil())
-						Expect(err).To(HaveOccurred())
-						Expect(err.Error()).To(Equal(expected.Error()))
-					})
-
-					It("works when incrementing major version", func() {
-						path := filepath.Join(changelogutils.ChangelogDirectory, "v0.6.0", filename1)
-						file1 := github.CommitFile{Filename: &path, Status: &added}
-						cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
-						repoClient.EXPECT().
-							CompareCommits(ctx, base, sha).
-							Return(&cc, nil)
-						code.EXPECT().
-							GetFileContents(ctx, path).
-							Return([]byte(validBreakingChangelog), nil).Times(2)
-						repoClient.EXPECT().
-							FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-							Return("v0.5.0", nil)
-						code.EXPECT().
-							ListFiles(ctx, changelogutils.ChangelogDirectory).
-							Return([]os.FileInfo{getChangelogDir("v0.6.0")}, nil)
-						code.EXPECT().
-							ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, "v0.6.0")).
-							Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
-
-						file, err := validator.ValidateChangelog(ctx)
-						Expect(err).To(BeNil())
-						Expect(file).NotTo(BeNil())
-					})
-
-				})
-
-				Context("major version is 1.y.z", func() {
-
-					DescribeTable("correctly enforces version bump rules",
-						validateVersionBump,
-						Entry("breaking change with patch bump", "v1.0.0", "v1.0.1", validBreakingChangelog, true),
-						Entry("breaking change with minor bump", "v1.0.0", "v1.1.0", validBreakingChangelog, true),
-						Entry("breaking change with major bump", "v1.0.0", "v2.0.0", validBreakingChangelog, false),
-						Entry("new feature with patch bump", "v1.0.0", "v1.0.1", validNewFeatureChangelog, true),
-						Entry("new feature with minor bump", "v1.0.0", "v1.1.0", validNewFeatureChangelog, false),
-						Entry("new feature with major bump", "v1.0.0", "v2.0.0", validNewFeatureChangelog, true),
-						Entry("non-breaking with patch bump", "v1.0.0", "v1.0.1", validNonBreakingNorNewFeatureChangelog, false),
-						Entry("non-breaking with minor bump", "v1.0.0", "v1.1.0", validNonBreakingNorNewFeatureChangelog, true),
-						Entry("non-breaking with major bump", "v1.0.0", "v2.0.0", validNonBreakingNorNewFeatureChangelog, true),
-					)
-				})
-
-				Context("moving from 0.x to 1.x", func() {
-
-					It("works for stable api release", func() {
-						path := filepath.Join(changelogutils.ChangelogDirectory, "v1.0.0", filename1)
-						file1 := github.CommitFile{Filename: &path, Status: &added}
-						cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
-						repoClient.EXPECT().
-							CompareCommits(ctx, base, sha).
-							Return(&cc, nil)
-						code.EXPECT().
-							GetFileContents(ctx, path).
-							Return([]byte(validStableReleaseChangelog), nil).Times(2)
-						repoClient.EXPECT().
-							FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-							Return("v0.5.0", nil)
-						code.EXPECT().
-							ListFiles(ctx, changelogutils.ChangelogDirectory).
-							Return([]os.FileInfo{getChangelogDir("v1.0.0")}, nil)
-						code.EXPECT().
-							ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, "v1.0.0")).
-							Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
-
-						file, err := validator.ValidateChangelog(ctx)
-						Expect(err).To(BeNil())
-						Expect(file).NotTo(BeNil())
-					})
-
-					It("errors when not incrementing for stable api release", func() {
-						path := filepath.Join(changelogutils.ChangelogDirectory, nextTag, filename1)
-						file1 := github.CommitFile{Filename: &path, Status: &added}
-						cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
-						repoClient.EXPECT().
-							CompareCommits(ctx, base, sha).
-							Return(&cc, nil)
-						code.EXPECT().
-							GetFileContents(ctx, path).
-							Return([]byte(validStableReleaseChangelog), nil).Times(2)
-						repoClient.EXPECT().
-							FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-							Return("v0.5.0", nil)
-						code.EXPECT().
-							ListFiles(ctx, changelogutils.ChangelogDirectory).
-							Return([]os.FileInfo{getChangelogDir(nextTag)}, nil)
-						code.EXPECT().
-							ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, nextTag)).
-							Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
-
-						expected := changelogutils.InvalidUseOfStableApiError(nextTag)
-						file, err := validator.ValidateChangelog(ctx)
-						Expect(err.Error()).To(Equal(expected.Error()))
-						Expect(file).To(BeNil())
-					})
-				})
-			})
-
-			Context("incrementing versions with relaxed validation", func() {
-
-				BeforeEach(func() {
-					relaxedValidationSettingsExists()
-				})
-
-				Context("major version zero 0.y.z", func() {
-
-					It("allows not incrementing major version", func() {
-						file1 := github.CommitFile{Filename: &path1, Status: &added}
-						cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
-						repoClient.EXPECT().
-							CompareCommits(ctx, base, sha).
-							Return(&cc, nil)
-						code.EXPECT().
-							GetFileContents(ctx, path1).
-							Return([]byte(validBreakingChangelog), nil).Times(2)
-						repoClient.EXPECT().
-							FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-							Return("v0.5.0", nil)
-						code.EXPECT().
-							ListFiles(ctx, changelogutils.ChangelogDirectory).
-							Return([]os.FileInfo{getChangelogDir(tag)}, nil)
-						code.EXPECT().
-							ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, tag)).
-							Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
-
-						file, err := validator.ValidateChangelog(ctx)
-						Expect(file).NotTo(BeNil())
-						Expect(err).To(BeNil())
-					})
-
-					It("works when incrementing major version", func() {
-						path := filepath.Join(changelogutils.ChangelogDirectory, "v0.6.0", filename1)
-						file1 := github.CommitFile{Filename: &path, Status: &added}
-						cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
-						repoClient.EXPECT().
-							CompareCommits(ctx, base, sha).
-							Return(&cc, nil)
-						code.EXPECT().
-							GetFileContents(ctx, path).
-							Return([]byte(validBreakingChangelog), nil).Times(2)
-						repoClient.EXPECT().
-							FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-							Return("v0.5.0", nil)
-						code.EXPECT().
-							ListFiles(ctx, changelogutils.ChangelogDirectory).
-							Return([]os.FileInfo{getChangelogDir("v0.6.0")}, nil)
-						code.EXPECT().
-							ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, "v0.6.0")).
-							Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
-
-						file, err := validator.ValidateChangelog(ctx)
-						Expect(err).To(BeNil())
-						Expect(file).NotTo(BeNil())
-					})
-
-				})
-
-				Context("major version is 1.y.z", func() {
-
-					DescribeTable("doesn't enforce version bump rules",
-						validateVersionBump,
-						Entry("breaking change with patch bump", "v1.0.0", "v1.0.1", validBreakingChangelog, false),
-						Entry("breaking change with minor bump", "v1.0.0", "v1.1.0", validBreakingChangelog, false),
-						Entry("breaking change with major bump", "v1.0.0", "v2.0.0", validBreakingChangelog, false),
-						Entry("new feature with patch bump", "v1.0.0", "v1.0.1", validNewFeatureChangelog, false),
-						Entry("new feature with minor bump", "v1.0.0", "v1.1.0", validNewFeatureChangelog, false),
-						Entry("new feature with major bump", "v1.0.0", "v2.0.0", validNewFeatureChangelog, false),
-						Entry("non-breaking with patch bump", "v1.0.0", "v1.0.1", validNonBreakingNorNewFeatureChangelog, false),
-						Entry("non-breaking with minor bump", "v1.0.0", "v1.1.0", validNonBreakingNorNewFeatureChangelog, false),
-						Entry("non-breaking with major bump", "v1.0.0", "v2.0.0", validNonBreakingNorNewFeatureChangelog, false),
-						Entry("stable release that skips to a future version", "v1.0.0-rc6", "v1.2.0", validNonBreakingNorNewFeatureChangelog, false),
-					)
-				})
-
-				Context("moving from 0.x to 1.x", func() {
-
-					It("works for stable api release", func() {
-						path := filepath.Join(changelogutils.ChangelogDirectory, "v1.0.0", filename1)
-						file1 := github.CommitFile{Filename: &path, Status: &added}
-						cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
-						repoClient.EXPECT().
-							CompareCommits(ctx, base, sha).
-							Return(&cc, nil)
-						code.EXPECT().
-							GetFileContents(ctx, path).
-							Return([]byte(validStableReleaseChangelog), nil).Times(2)
-						repoClient.EXPECT().
-							FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-							Return("v0.5.0", nil)
-						code.EXPECT().
-							ListFiles(ctx, changelogutils.ChangelogDirectory).
-							Return([]os.FileInfo{getChangelogDir("v1.0.0")}, nil)
-						code.EXPECT().
-							ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, "v1.0.0")).
-							Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
-
-						file, err := validator.ValidateChangelog(ctx)
-						Expect(err).To(BeNil())
-						Expect(file).NotTo(BeNil())
-					})
-
-					It("errors when not incrementing for stable api release", func() {
-						path := filepath.Join(changelogutils.ChangelogDirectory, nextTag, filename1)
-						file1 := github.CommitFile{Filename: &path, Status: &added}
-						cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
-						repoClient.EXPECT().
-							CompareCommits(ctx, base, sha).
-							Return(&cc, nil)
-						code.EXPECT().
-							GetFileContents(ctx, path).
-							Return([]byte(validStableReleaseChangelog), nil).Times(2)
-						repoClient.EXPECT().
-							FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-							Return("v0.5.0", nil)
-						code.EXPECT().
-							ListFiles(ctx, changelogutils.ChangelogDirectory).
-							Return([]os.FileInfo{getChangelogDir(nextTag)}, nil)
-						code.EXPECT().
-							ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, nextTag)).
-							Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
-
-						expected := changelogutils.InvalidUseOfStableApiError(nextTag)
-						file, err := validator.ValidateChangelog(ctx)
-						Expect(err.Error()).To(Equal(expected.Error()))
-						Expect(file).To(BeNil())
-					})
-				})
-			})
-
-			Context("label workflow", func() {
-
-				labelWorkflow := func(lastTag, nextTag, contents string, settingsFunc func()) {
-					path := filepath.Join(changelogutils.ChangelogDirectory, nextTag, filename1)
-					file1 := github.CommitFile{Filename: &path, Status: &added}
-					cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
-					repoClient.EXPECT().
-						CompareCommits(ctx, base, sha).
-						Return(&cc, nil)
-					code.EXPECT().
-						GetFileContents(ctx, path).
-						Return([]byte(validBreakingChangelog), nil)
-					repoClient.EXPECT().
-						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-						Return(lastTag, nil)
-					code.EXPECT().
-						ListFiles(ctx, changelogutils.ChangelogDirectory).
-						Return([]os.FileInfo{getChangelogDir(nextTag)}, nil)
-					code.EXPECT().
-						ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, nextTag)).
-						Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
-					code.EXPECT().
-						GetFileContents(ctx, path).
-						Return([]byte(contents), nil)
-
-					settingsFunc()
-
-					file, err := validator.ValidateChangelog(ctx)
-					Expect(err).To(BeNil())
-					Expect(file).NotTo(BeNil())
-				}
-
-				DescribeTable("label workflow cases",
-					labelWorkflow,
-					Entry("initial rc", "v0.20.5", "v1.0.0-rc1", validBreakingChangelog, noValidationSettingsExist),
-					Entry("initial rc relaxed", "v0.20.5", "v1.0.0-rc1", validBreakingChangelog, relaxedValidationSettingsExists),
-					Entry("incrementing rc", "v1.0.0-rc1", "v1.0.0-rc2", validBreakingChangelog, noValidationSettingsExist),
-					Entry("incrementing rc relaxed", "v1.0.0-rc1", "v1.0.0-rc2", validBreakingChangelog, relaxedValidationSettingsExists),
-					Entry("stable release after rc for 1.0", "v1.0.0-rc2", "v1.0.0", validStableReleaseChangelog, noValidationSettingsExist),
-					Entry("stable release after rc for 1.0 relaxed", "v1.0.0-rc2", "v1.0.0", validStableReleaseChangelog, relaxedValidationSettingsExists),
-					Entry("stable release after rc for 1.1", "v1.1.0-rc2", "v1.1.0", validStableReleaseChangelog, noValidationSettingsExist),
-					Entry("stable release after rc for 1.1 relaxed", "v1.1.0-rc2", "v1.1.0", validStableReleaseChangelog, relaxedValidationSettingsExists),
-					Entry("initial rc after for 1.1", "v1.0.0", "v1.1.0-rc1", validNewFeatureChangelog, noValidationSettingsExist),
-					Entry("initial rc after for 1.1 relaxed", "v1.0.0", "v1.1.0-rc1", validNewFeatureChangelog, relaxedValidationSettingsExists),
-					Entry("foo3 to bar1", "v1.0.0-foo3", "v1.0.0-bar1", validNewFeatureChangelog, noValidationSettingsExist),
-					Entry("foo3 to bar1 relaxed", "v1.0.0-foo3", "v1.0.0-bar1", validNewFeatureChangelog, relaxedValidationSettingsExists),
-					Entry("foo1 to bar1", "v1.0.0-foo1", "v1.0.0-bar1", validNewFeatureChangelog, noValidationSettingsExist),
-					Entry("foo1 to bar1 relaxed", "v1.0.0-foo1", "v1.0.0-bar1", validNewFeatureChangelog, relaxedValidationSettingsExists),
-					Entry("foo1 to bar3", "v1.0.0-foo1", "v1.0.0-bar3", validNewFeatureChangelog, noValidationSettingsExist),
-					Entry("foo1 to bar3 relaxed", "v1.0.0-foo1", "v1.0.0-bar3", validNewFeatureChangelog, relaxedValidationSettingsExists),
-					Entry("foo1 to next minor", "v1.1.0-foo1", "v1.1.0", validNewFeatureChangelog, noValidationSettingsExist),
-					Entry("foo1 to next minor relaxed", "v1.1.0-foo1", "v1.1.0", validNewFeatureChangelog, relaxedValidationSettingsExists))
-			})
-
-			Context("settings with allowed labels", func() {
-
-				setup := func(setupTag string) {
-					path := filepath.Join(changelogutils.ChangelogDirectory, setupTag, filename1)
-					file1 := github.CommitFile{Filename: &path, Status: &added}
-					cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
-					repoClient.EXPECT().
-						CompareCommits(ctx, base, sha).
-						Return(&cc, nil)
-					code.EXPECT().
-						GetFileContents(ctx, path).
-						Return([]byte(validBreakingChangelog), nil).Times(2)
-					repoClient.EXPECT().
-						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-						Return("v0.5.0", nil)
-					code.EXPECT().
-						ListFiles(ctx, changelogutils.ChangelogDirectory).
-						Return([]os.FileInfo{getChangelogDir(setupTag)}, nil)
-					code.EXPECT().
-						ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, setupTag)).
-						Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
-				}
-
-				allowedLabelsSettingsExists := func() {
-					repoClient.EXPECT().FileExists(ctx, sha, changelogutils.GetValidationSettingsPath()).Return(true, nil)
-					code.EXPECT().GetFileContents(ctx, changelogutils.GetValidationSettingsPath()).Return([]byte(allowedLabelsYaml), nil)
-				}
-
-				It("accepts a label in allowed labels", func() {
-					setup("v0.5.1-beta1")
-					allowedLabelsSettingsExists()
-					file, err := validator.ValidateChangelog(ctx)
-					Expect(file).NotTo(BeNil())
-					Expect(err).To(BeNil())
-				})
-
-				It("rejects a label not in allowed labels", func() {
-					setup("v0.5.1-foo1")
-					allowedLabelsSettingsExists()
-					file, err := validator.ValidateChangelog(ctx)
-					Expect(file).To(BeNil())
-					Expect(err.Error()).To(Equal(changelogutils.InvalidLabelError("foo", []string{"beta", "rc"}).Error()))
-				})
-			})
-
-			Context("invalid settings", func() {
-
-				setup := func() {
-					file1 := github.CommitFile{Filename: &path1, Status: &added}
-					cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
-					repoClient.EXPECT().
-						CompareCommits(ctx, base, sha).
-						Return(&cc, nil)
-					code.EXPECT().
-						GetFileContents(ctx, path1).
-						Return([]byte(validBreakingChangelog), nil).Times(2)
-					repoClient.EXPECT().
-						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
-						Return("v0.5.0", nil)
-					code.EXPECT().
-						ListFiles(ctx, changelogutils.ChangelogDirectory).
-						Return([]os.FileInfo{getChangelogDir(tag)}, nil)
-					code.EXPECT().
-						ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, tag)).
-						Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
-				}
-
-				It("propagates error if checking for validation.yaml existence fails", func() {
-					setup()
-					emptyErr := eris.Errorf("")
-					repoClient.EXPECT().
-						FileExists(ctx, sha, changelogutils.GetValidationSettingsPath()).
-						Return(false, emptyErr)
-					file, err := validator.ValidateChangelog(ctx)
-					Expect(file).To(BeNil())
-					Expect(err).NotTo(BeNil())
-					Expect(err.Error()).To(Equal(changelogutils.UnableToGetSettingsError(emptyErr).Error()))
-				})
-
-				It("propagates error if reading validation.yaml fails", func() {
-					setup()
-					emptyErr := eris.Errorf("")
-					repoClient.EXPECT().
-						FileExists(ctx, sha, changelogutils.GetValidationSettingsPath()).
-						Return(true, nil)
-					code.EXPECT().
-						GetFileContents(ctx, changelogutils.GetValidationSettingsPath()).
-						Return(nil, emptyErr)
-					file, err := validator.ValidateChangelog(ctx)
-					Expect(file).To(BeNil())
-					Expect(err).NotTo(BeNil())
-					Expect(err.Error()).To(Equal(changelogutils.UnableToGetSettingsError(emptyErr).Error()))
-				})
-
-				It("propagates error if marshalling validation.yaml fails", func() {
-					setup()
-					emptyErr := eris.Errorf("")
-					repoClient.EXPECT().
-						FileExists(ctx, sha, changelogutils.GetValidationSettingsPath()).
-						Return(true, nil)
-					code.EXPECT().
-						GetFileContents(ctx, changelogutils.GetValidationSettingsPath()).
-						Return([]byte("fakeyaml"), nil)
-					file, err := validator.ValidateChangelog(ctx)
-					Expect(file).To(BeNil())
-					Expect(err).NotTo(BeNil())
-					Expect(err.Error()).To(ContainSubstring(changelogutils.UnableToGetSettingsError(emptyErr).Error()))
-				})
-			})
-
-			Context("PR adding validation settings", func() {
-
-				It("properly ignores validation when computing new changelog files", func() {
-					relaxedValidationSettingsExists()
-					validationPath := changelogutils.GetValidationSettingsPath()
-					file1 := github.CommitFile{Filename: &path1, Status: &added}
-					file2 := github.CommitFile{Filename: &validationPath, Status: &added}
-					cc := github.CommitsComparison{Files: []*github.CommitFile{&file1, &file2}}
 					repoClient.EXPECT().
 						CompareCommits(ctx, base, sha).
 						Return(&cc, nil)
@@ -817,6 +366,452 @@ var _ = Describe("changelog validator utils", func() {
 					Expect(file).NotTo(BeNil())
 					Expect(err).To(BeNil())
 				})
+
+				It("errors when not incrementing major version", func() {
+					file1 := github.CommitFile{Filename: &path1, Status: &added}
+					cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
+					repoClient.EXPECT().
+						CompareCommits(ctx, base, sha).
+						Return(&cc, nil)
+					code.EXPECT().
+						GetFileContents(ctx, path1).
+						Return([]byte(validBreakingChangelog), nil).Times(2)
+					repoClient.EXPECT().
+						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+						Return("v0.5.0", nil)
+					code.EXPECT().
+						ListFiles(ctx, changelogutils.ChangelogDirectory).
+						Return([]os.FileInfo{getChangelogDir(tag)}, nil)
+					code.EXPECT().
+						ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, tag)).
+						Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
+
+					expected := changelogutils.UnexpectedProposedVersionError("v0.6.0", tag)
+					file, err := validator.ValidateChangelog(ctx)
+					Expect(file).To(BeNil())
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(Equal(expected.Error()))
+				})
+
+				It("works when incrementing major version", func() {
+					path := filepath.Join(changelogutils.ChangelogDirectory, "v0.6.0", filename1)
+					file1 := github.CommitFile{Filename: &path, Status: &added}
+					cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
+					repoClient.EXPECT().
+						CompareCommits(ctx, base, sha).
+						Return(&cc, nil)
+					code.EXPECT().
+						GetFileContents(ctx, path).
+						Return([]byte(validBreakingChangelog), nil).Times(2)
+					repoClient.EXPECT().
+						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+						Return("v0.5.0", nil)
+					code.EXPECT().
+						ListFiles(ctx, changelogutils.ChangelogDirectory).
+						Return([]os.FileInfo{getChangelogDir("v0.6.0")}, nil)
+					code.EXPECT().
+						ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, "v0.6.0")).
+						Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
+
+					file, err := validator.ValidateChangelog(ctx)
+					Expect(err).To(BeNil())
+					Expect(file).NotTo(BeNil())
+				})
+
+			})
+
+			Context("major version is 1.y.z", func() {
+
+				DescribeTable("correctly enforces version bump rules",
+					validateVersionBump,
+					Entry("breaking change with patch bump", "v1.0.0", "v1.0.1", validBreakingChangelog, true),
+					Entry("breaking change with minor bump", "v1.0.0", "v1.1.0", validBreakingChangelog, true),
+					Entry("breaking change with major bump", "v1.0.0", "v2.0.0", validBreakingChangelog, false),
+					Entry("new feature with patch bump", "v1.0.0", "v1.0.1", validNewFeatureChangelog, true),
+					Entry("new feature with minor bump", "v1.0.0", "v1.1.0", validNewFeatureChangelog, false),
+					Entry("new feature with major bump", "v1.0.0", "v2.0.0", validNewFeatureChangelog, true),
+					Entry("non-breaking with patch bump", "v1.0.0", "v1.0.1", validNonBreakingNorNewFeatureChangelog, false),
+					Entry("non-breaking with minor bump", "v1.0.0", "v1.1.0", validNonBreakingNorNewFeatureChangelog, true),
+					Entry("non-breaking with major bump", "v1.0.0", "v2.0.0", validNonBreakingNorNewFeatureChangelog, true),
+				)
+			})
+
+			Context("moving from 0.x to 1.x", func() {
+
+				It("works for stable api release", func() {
+					path := filepath.Join(changelogutils.ChangelogDirectory, "v1.0.0", filename1)
+					file1 := github.CommitFile{Filename: &path, Status: &added}
+					cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
+					repoClient.EXPECT().
+						CompareCommits(ctx, base, sha).
+						Return(&cc, nil)
+					code.EXPECT().
+						GetFileContents(ctx, path).
+						Return([]byte(validStableReleaseChangelog), nil).Times(2)
+					repoClient.EXPECT().
+						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+						Return("v0.5.0", nil)
+					code.EXPECT().
+						ListFiles(ctx, changelogutils.ChangelogDirectory).
+						Return([]os.FileInfo{getChangelogDir("v1.0.0")}, nil)
+					code.EXPECT().
+						ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, "v1.0.0")).
+						Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
+
+					file, err := validator.ValidateChangelog(ctx)
+					Expect(err).To(BeNil())
+					Expect(file).NotTo(BeNil())
+				})
+
+				It("errors when not incrementing for stable api release", func() {
+					path := filepath.Join(changelogutils.ChangelogDirectory, nextTag, filename1)
+					file1 := github.CommitFile{Filename: &path, Status: &added}
+					cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
+					repoClient.EXPECT().
+						CompareCommits(ctx, base, sha).
+						Return(&cc, nil)
+					code.EXPECT().
+						GetFileContents(ctx, path).
+						Return([]byte(validStableReleaseChangelog), nil).Times(2)
+					repoClient.EXPECT().
+						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+						Return("v0.5.0", nil)
+					code.EXPECT().
+						ListFiles(ctx, changelogutils.ChangelogDirectory).
+						Return([]os.FileInfo{getChangelogDir(nextTag)}, nil)
+					code.EXPECT().
+						ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, nextTag)).
+						Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
+
+					expected := changelogutils.InvalidUseOfStableApiError(nextTag)
+					file, err := validator.ValidateChangelog(ctx)
+					Expect(err.Error()).To(Equal(expected.Error()))
+					Expect(file).To(BeNil())
+				})
+			})
+		})
+
+		Context("incrementing versions with relaxed validation", func() {
+
+			BeforeEach(func() {
+				relaxedValidationSettingsExists()
+			})
+
+			Context("major version zero 0.y.z", func() {
+
+				It("allows not incrementing major version", func() {
+					file1 := github.CommitFile{Filename: &path1, Status: &added}
+					cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
+					repoClient.EXPECT().
+						CompareCommits(ctx, base, sha).
+						Return(&cc, nil)
+					code.EXPECT().
+						GetFileContents(ctx, path1).
+						Return([]byte(validBreakingChangelog), nil).Times(2)
+					repoClient.EXPECT().
+						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+						Return("v0.5.0", nil)
+					code.EXPECT().
+						ListFiles(ctx, changelogutils.ChangelogDirectory).
+						Return([]os.FileInfo{getChangelogDir(tag)}, nil)
+					code.EXPECT().
+						ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, tag)).
+						Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
+
+					file, err := validator.ValidateChangelog(ctx)
+					Expect(file).NotTo(BeNil())
+					Expect(err).To(BeNil())
+				})
+
+				It("works when incrementing major version", func() {
+					path := filepath.Join(changelogutils.ChangelogDirectory, "v0.6.0", filename1)
+					file1 := github.CommitFile{Filename: &path, Status: &added}
+					cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
+					repoClient.EXPECT().
+						CompareCommits(ctx, base, sha).
+						Return(&cc, nil)
+					code.EXPECT().
+						GetFileContents(ctx, path).
+						Return([]byte(validBreakingChangelog), nil).Times(2)
+					repoClient.EXPECT().
+						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+						Return("v0.5.0", nil)
+					code.EXPECT().
+						ListFiles(ctx, changelogutils.ChangelogDirectory).
+						Return([]os.FileInfo{getChangelogDir("v0.6.0")}, nil)
+					code.EXPECT().
+						ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, "v0.6.0")).
+						Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
+
+					file, err := validator.ValidateChangelog(ctx)
+					Expect(err).To(BeNil())
+					Expect(file).NotTo(BeNil())
+				})
+
+			})
+
+			Context("major version is 1.y.z", func() {
+
+				DescribeTable("doesn't enforce version bump rules",
+					validateVersionBump,
+					Entry("breaking change with patch bump", "v1.0.0", "v1.0.1", validBreakingChangelog, false),
+					Entry("breaking change with minor bump", "v1.0.0", "v1.1.0", validBreakingChangelog, false),
+					Entry("breaking change with major bump", "v1.0.0", "v2.0.0", validBreakingChangelog, false),
+					Entry("new feature with patch bump", "v1.0.0", "v1.0.1", validNewFeatureChangelog, false),
+					Entry("new feature with minor bump", "v1.0.0", "v1.1.0", validNewFeatureChangelog, false),
+					Entry("new feature with major bump", "v1.0.0", "v2.0.0", validNewFeatureChangelog, false),
+					Entry("non-breaking with patch bump", "v1.0.0", "v1.0.1", validNonBreakingNorNewFeatureChangelog, false),
+					Entry("non-breaking with minor bump", "v1.0.0", "v1.1.0", validNonBreakingNorNewFeatureChangelog, false),
+					Entry("non-breaking with major bump", "v1.0.0", "v2.0.0", validNonBreakingNorNewFeatureChangelog, false),
+					Entry("stable release that skips to a future version", "v1.0.0-rc6", "v1.2.0", validNonBreakingNorNewFeatureChangelog, false),
+				)
+			})
+
+			Context("moving from 0.x to 1.x", func() {
+
+				It("works for stable api release", func() {
+					path := filepath.Join(changelogutils.ChangelogDirectory, "v1.0.0", filename1)
+					file1 := github.CommitFile{Filename: &path, Status: &added}
+					cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
+					repoClient.EXPECT().
+						CompareCommits(ctx, base, sha).
+						Return(&cc, nil)
+					code.EXPECT().
+						GetFileContents(ctx, path).
+						Return([]byte(validStableReleaseChangelog), nil).Times(2)
+					repoClient.EXPECT().
+						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+						Return("v0.5.0", nil)
+					code.EXPECT().
+						ListFiles(ctx, changelogutils.ChangelogDirectory).
+						Return([]os.FileInfo{getChangelogDir("v1.0.0")}, nil)
+					code.EXPECT().
+						ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, "v1.0.0")).
+						Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
+
+					file, err := validator.ValidateChangelog(ctx)
+					Expect(err).To(BeNil())
+					Expect(file).NotTo(BeNil())
+				})
+
+				It("errors when not incrementing for stable api release", func() {
+					path := filepath.Join(changelogutils.ChangelogDirectory, nextTag, filename1)
+					file1 := github.CommitFile{Filename: &path, Status: &added}
+					cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
+					repoClient.EXPECT().
+						CompareCommits(ctx, base, sha).
+						Return(&cc, nil)
+					code.EXPECT().
+						GetFileContents(ctx, path).
+						Return([]byte(validStableReleaseChangelog), nil).Times(2)
+					repoClient.EXPECT().
+						FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+						Return("v0.5.0", nil)
+					code.EXPECT().
+						ListFiles(ctx, changelogutils.ChangelogDirectory).
+						Return([]os.FileInfo{getChangelogDir(nextTag)}, nil)
+					code.EXPECT().
+						ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, nextTag)).
+						Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
+
+					expected := changelogutils.InvalidUseOfStableApiError(nextTag)
+					file, err := validator.ValidateChangelog(ctx)
+					Expect(err.Error()).To(Equal(expected.Error()))
+					Expect(file).To(BeNil())
+				})
+			})
+		})
+
+		Context("label workflow", func() {
+
+			labelWorkflow := func(lastTag, nextTag, contents string, settingsFunc func()) {
+				path := filepath.Join(changelogutils.ChangelogDirectory, nextTag, filename1)
+				file1 := github.CommitFile{Filename: &path, Status: &added}
+				cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
+				repoClient.EXPECT().
+					CompareCommits(ctx, base, sha).
+					Return(&cc, nil)
+				code.EXPECT().
+					GetFileContents(ctx, path).
+					Return([]byte(validBreakingChangelog), nil)
+				repoClient.EXPECT().
+					FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+					Return(lastTag, nil)
+				code.EXPECT().
+					ListFiles(ctx, changelogutils.ChangelogDirectory).
+					Return([]os.FileInfo{getChangelogDir(nextTag)}, nil)
+				code.EXPECT().
+					ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, nextTag)).
+					Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
+				code.EXPECT().
+					GetFileContents(ctx, path).
+					Return([]byte(contents), nil)
+
+				settingsFunc()
+
+				file, err := validator.ValidateChangelog(ctx)
+				Expect(err).To(BeNil())
+				Expect(file).NotTo(BeNil())
+			}
+
+			DescribeTable("label workflow cases",
+				labelWorkflow,
+				Entry("initial rc", "v0.20.5", "v1.0.0-rc1", validBreakingChangelog, noValidationSettingsExist),
+				Entry("initial rc relaxed", "v0.20.5", "v1.0.0-rc1", validBreakingChangelog, relaxedValidationSettingsExists),
+				Entry("incrementing rc", "v1.0.0-rc1", "v1.0.0-rc2", validBreakingChangelog, noValidationSettingsExist),
+				Entry("incrementing rc relaxed", "v1.0.0-rc1", "v1.0.0-rc2", validBreakingChangelog, relaxedValidationSettingsExists),
+				Entry("stable release after rc for 1.0", "v1.0.0-rc2", "v1.0.0", validStableReleaseChangelog, noValidationSettingsExist),
+				Entry("stable release after rc for 1.0 relaxed", "v1.0.0-rc2", "v1.0.0", validStableReleaseChangelog, relaxedValidationSettingsExists),
+				Entry("stable release after rc for 1.1", "v1.1.0-rc2", "v1.1.0", validStableReleaseChangelog, noValidationSettingsExist),
+				Entry("stable release after rc for 1.1 relaxed", "v1.1.0-rc2", "v1.1.0", validStableReleaseChangelog, relaxedValidationSettingsExists),
+				Entry("initial rc after for 1.1", "v1.0.0", "v1.1.0-rc1", validNewFeatureChangelog, noValidationSettingsExist),
+				Entry("initial rc after for 1.1 relaxed", "v1.0.0", "v1.1.0-rc1", validNewFeatureChangelog, relaxedValidationSettingsExists),
+				Entry("foo3 to bar1", "v1.0.0-foo3", "v1.0.0-bar1", validNewFeatureChangelog, noValidationSettingsExist),
+				Entry("foo3 to bar1 relaxed", "v1.0.0-foo3", "v1.0.0-bar1", validNewFeatureChangelog, relaxedValidationSettingsExists),
+				Entry("foo1 to bar1", "v1.0.0-foo1", "v1.0.0-bar1", validNewFeatureChangelog, noValidationSettingsExist),
+				Entry("foo1 to bar1 relaxed", "v1.0.0-foo1", "v1.0.0-bar1", validNewFeatureChangelog, relaxedValidationSettingsExists),
+				Entry("foo1 to bar3", "v1.0.0-foo1", "v1.0.0-bar3", validNewFeatureChangelog, noValidationSettingsExist),
+				Entry("foo1 to bar3 relaxed", "v1.0.0-foo1", "v1.0.0-bar3", validNewFeatureChangelog, relaxedValidationSettingsExists),
+				Entry("foo1 to next minor", "v1.1.0-foo1", "v1.1.0", validNewFeatureChangelog, noValidationSettingsExist),
+				Entry("foo1 to next minor relaxed", "v1.1.0-foo1", "v1.1.0", validNewFeatureChangelog, relaxedValidationSettingsExists))
+		})
+
+		Context("settings with allowed labels", func() {
+
+			setup := func(setupTag string) {
+				path := filepath.Join(changelogutils.ChangelogDirectory, setupTag, filename1)
+				file1 := github.CommitFile{Filename: &path, Status: &added}
+				cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
+				repoClient.EXPECT().
+					CompareCommits(ctx, base, sha).
+					Return(&cc, nil)
+				code.EXPECT().
+					GetFileContents(ctx, path).
+					Return([]byte(validBreakingChangelog), nil).Times(2)
+				repoClient.EXPECT().
+					FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+					Return("v0.5.0", nil)
+				code.EXPECT().
+					ListFiles(ctx, changelogutils.ChangelogDirectory).
+					Return([]os.FileInfo{getChangelogDir(setupTag)}, nil)
+				code.EXPECT().
+					ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, setupTag)).
+					Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
+			}
+
+			allowedLabelsSettingsExists := func() {
+				repoClient.EXPECT().FileExists(ctx, sha, changelogutils.GetValidationSettingsPath()).Return(true, nil)
+				code.EXPECT().GetFileContents(ctx, changelogutils.GetValidationSettingsPath()).Return([]byte(allowedLabelsYaml), nil)
+			}
+
+			It("accepts a label in allowed labels", func() {
+				setup("v0.5.1-beta1")
+				allowedLabelsSettingsExists()
+				file, err := validator.ValidateChangelog(ctx)
+				Expect(file).NotTo(BeNil())
+				Expect(err).To(BeNil())
+			})
+
+			It("rejects a label not in allowed labels", func() {
+				setup("v0.5.1-foo1")
+				allowedLabelsSettingsExists()
+				file, err := validator.ValidateChangelog(ctx)
+				Expect(file).To(BeNil())
+				Expect(err.Error()).To(Equal(changelogutils.InvalidLabelError("foo", []string{"beta", "rc"}).Error()))
+			})
+		})
+
+		Context("invalid settings", func() {
+
+			setup := func() {
+				file1 := github.CommitFile{Filename: &path1, Status: &added}
+				cc := github.CommitsComparison{Files: []*github.CommitFile{&file1}}
+				repoClient.EXPECT().
+					CompareCommits(ctx, base, sha).
+					Return(&cc, nil)
+				code.EXPECT().
+					GetFileContents(ctx, path1).
+					Return([]byte(validBreakingChangelog), nil).Times(2)
+				repoClient.EXPECT().
+					FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+					Return("v0.5.0", nil)
+				code.EXPECT().
+					ListFiles(ctx, changelogutils.ChangelogDirectory).
+					Return([]os.FileInfo{getChangelogDir(tag)}, nil)
+				code.EXPECT().
+					ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, tag)).
+					Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
+			}
+
+			It("propagates error if checking for validation.yaml existence fails", func() {
+				setup()
+				emptyErr := eris.Errorf("")
+				repoClient.EXPECT().
+					FileExists(ctx, sha, changelogutils.GetValidationSettingsPath()).
+					Return(false, emptyErr)
+				file, err := validator.ValidateChangelog(ctx)
+				Expect(file).To(BeNil())
+				Expect(err).NotTo(BeNil())
+				Expect(err.Error()).To(Equal(changelogutils.UnableToGetSettingsError(emptyErr).Error()))
+			})
+
+			It("propagates error if reading validation.yaml fails", func() {
+				setup()
+				emptyErr := eris.Errorf("")
+				repoClient.EXPECT().
+					FileExists(ctx, sha, changelogutils.GetValidationSettingsPath()).
+					Return(true, nil)
+				code.EXPECT().
+					GetFileContents(ctx, changelogutils.GetValidationSettingsPath()).
+					Return(nil, emptyErr)
+				file, err := validator.ValidateChangelog(ctx)
+				Expect(file).To(BeNil())
+				Expect(err).NotTo(BeNil())
+				Expect(err.Error()).To(Equal(changelogutils.UnableToGetSettingsError(emptyErr).Error()))
+			})
+
+			It("propagates error if marshalling validation.yaml fails", func() {
+				setup()
+				emptyErr := eris.Errorf("")
+				repoClient.EXPECT().
+					FileExists(ctx, sha, changelogutils.GetValidationSettingsPath()).
+					Return(true, nil)
+				code.EXPECT().
+					GetFileContents(ctx, changelogutils.GetValidationSettingsPath()).
+					Return([]byte("fakeyaml"), nil)
+				file, err := validator.ValidateChangelog(ctx)
+				Expect(file).To(BeNil())
+				Expect(err).NotTo(BeNil())
+				Expect(err.Error()).To(ContainSubstring(changelogutils.UnableToGetSettingsError(emptyErr).Error()))
+			})
+		})
+
+		Context("PR adding validation settings", func() {
+
+			It("properly ignores validation when computing new changelog files", func() {
+				relaxedValidationSettingsExists()
+				validationPath := changelogutils.GetValidationSettingsPath()
+				file1 := github.CommitFile{Filename: &path1, Status: &added}
+				file2 := github.CommitFile{Filename: &validationPath, Status: &added}
+				cc := github.CommitsComparison{Files: []*github.CommitFile{&file1, &file2}}
+				repoClient.EXPECT().
+					CompareCommits(ctx, base, sha).
+					Return(&cc, nil)
+				code.EXPECT().
+					GetFileContents(ctx, path1).
+					Return([]byte(validChangelog1), nil).Times(2)
+				repoClient.EXPECT().
+					FindLatestTagIncludingPrereleaseBeforeSha(ctx, base).
+					Return("v0.5.0", nil)
+				code.EXPECT().
+					ListFiles(ctx, changelogutils.ChangelogDirectory).
+					Return([]os.FileInfo{getChangelogDir(tag)}, nil)
+				code.EXPECT().
+					ListFiles(ctx, filepath.Join(changelogutils.ChangelogDirectory, tag)).
+					Return([]os.FileInfo{&mockFileInfo{name: filename1, isDir: false}}, nil)
+				file, err := validator.ValidateChangelog(ctx)
+				Expect(file).NotTo(BeNil())
+				Expect(err).To(BeNil())
 			})
 		})
 	})

--- a/versionutils/version_test.go
+++ b/versionutils/version_test.go
@@ -162,6 +162,22 @@ var _ = Describe("Version", func() {
 		)
 	})
 
+	FDescribe("IsGreaterThanTagWithLabelOrder", func() {
+		labelOrder := []string{"rc", "beta", "alpha", "frog"}
+		DescribeTable("it works", func(greater, lesser string, determinable, expected bool){
+			isGreater, isDeterminable, err := versionutils.IsGreaterThanTagWithLabelOrder(greater, lesser, labelOrder)
+			Expect(isGreater).To(Equal(expected))
+			Expect(isDeterminable).To(Equal(determinable))
+			Expect(err).To(BeNil())
+		},
+			Entry("rc1 is greater than beta1", "v1.0.0-rc1", "v1.0.0-beta1", true, true),
+			Entry("rc1 is greater than alpha1", "v1.0.0-rc1", "v1.0.0-alpha1", true, true),
+			Entry("beta1 is greater than alpha1", "v1.0.0-beta1", "v1.0.0-alpha1", true, true),
+			Entry("frog1 is not greater than beta1", "v1.0.0-frog1", "v1.0.0-beta1", true, false),
+			Entry("unknown label is indeterminable", "v1.0.0-cat1", "v1.0.0-beta1", false, false),
+			Entry("unknown label is indeterminable", "v1.0.0-beta1", "v1.0.0-dog1", false, false))
+	})
+
 	Context("GetVersionFromTag", func() {
 		It("works", func() {
 			Expect(versionutils.GetVersionFromTag("v0.1.2")).To(Equal("0.1.2"))

--- a/versionutils/version_test.go
+++ b/versionutils/version_test.go
@@ -162,7 +162,7 @@ var _ = Describe("Version", func() {
 		)
 	})
 
-	FDescribe("IsGreaterThanTagWithLabelOrder", func() {
+	Describe("IsGreaterThanTagWithLabelOrder", func() {
 		labelOrder := []string{"rc", "beta", "alpha", "frog"}
 		DescribeTable("it works", func(greater, lesser string, determinable, expected bool){
 			isGreater, isDeterminable, err := versionutils.IsGreaterThanTagWithLabelOrder(greater, lesser, labelOrder)


### PR DESCRIPTION
Adds `labelOrder` to changelogValidator. If `labelOrder` exists, then changelogValidator
      will now use the order specified in this array to tie-break tags with same versions but different labels.
      e.g. if e.g. labelOrder = [ beta, alpha, predev ], then 1.7.0-beta11 > 1.7.0-alpha5 > 1.7.0-predev9.
BOT NOTES: 
resolves https://github.com/solo-io/go-utils/issues/441