### PR TITLE
Fix line reporting in fail handler

### DIFF
--- a/changelog/v0.21.3/fix-fail-handler.yaml
+++ b/changelog/v0.21.3/fix-fail-handler.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: FIX
+  description: >
+    Fix the `RegisterCommonFailHandlers` function so that our custom fail handlers report correct line numbers on failures.
+  issueLink: https://github.com/solo-io/go-utils/issues/443

--- a/testutils/fail_handler.go
+++ b/testutils/fail_handler.go
@@ -21,9 +21,16 @@ func RegisterCommonFailHandlers() {
 func failHandler(message string, callerSkip ...int) {
 	fmt.Println("Fail handler msg", message)
 
-	for _, prefail := range preFails {
-		prefail()
+	for _, preFail := range preFails {
+		preFail()
 	}
-	Fail(message, callerSkip...)
 
+	// Account for this extra function in the call stack.
+	// Without this all failure messages will show the incorrect line number!
+	var shiftedCallerSkip []int
+	for _, i := range callerSkip {
+		shiftedCallerSkip = append(shiftedCallerSkip, i+1)
+	}
+
+	Fail(message, shiftedCallerSkip...)
 }


### PR DESCRIPTION
Examples are from running [these tests](https://github.com/solo-io/solo-projects/blob/34cd83404ab0a8f320ec83dbc6fa3d8e19d315d3/install/test/helm_suite_test.go#L38).

Before this change:
![image](https://user-images.githubusercontent.com/16148461/113303658-4f39b680-92cf-11eb-9e47-c6a3af3054f8.png)

After this change:
![image](https://user-images.githubusercontent.com/16148461/113303838-77291a00-92cf-11eb-9639-4f6267772878.png)

BOT NOTES: 
resolves https://github.com/solo-io/go-utils/issues/443