### PR TITLE
Always run testspace, even on failures

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -47,8 +47,8 @@ jobs:
     - uses: testspace-com/setup-testspace@v1
       with:
         domain: solo-io.testspace.com
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
     - name: Push result to Testspace server
       run: |
         testspace push --verbose "**/junit.xml"
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
Per https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#job-status-check-functions the default condition is `success()` which doesn't run if previous steps failed. This means that job failures weren't getting uploaded to testspace. This fixes that.