### PR TITLE
Build logger when an env var is set

### DIFF
--- a/changelog/v0.21.5/log-level-fix.yaml
+++ b/changelog/v0.21.5/log-level-fix.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: FIX
+  description: Fix setting of stat server log level when using the LOG_LEVEL environment variable
+  resolvesIssue: false
+  issueLink: https://github.com/solo-io/gloo/issues/4648

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -78,6 +78,13 @@ func StartStatsServerWithPort(startupOpts StartupOptions, addhandlers ...func(mu
 			setLevel = zapcore.InfoLevel
 		}
 		logLevel = zap.NewAtomicLevelAt(setLevel)
+
+		logConfig := zap.NewProductionConfig()
+		logConfig.Level = logLevel
+		logger, logErr := logConfig.Build()
+		if logErr == nil {
+			contextutils.SetFallbackLogger(logger.Sugar())
+		}
 	} else if startupOpts.LogLevel != nil {
 		logLevel = *startupOpts.LogLevel
 	} else {


### PR DESCRIPTION
When setting the stat server log level via an environment variable. previously the log config was not being built so logs would not be produced. This also prevented logs from being produced when set via the admin api after the server started without a log config. This fix builds the log config so that the log level is applied and logs are produced.

Tested this locally with a gloo image that pulled in this change and a defined the env var.