### PR TITLE
Fix github api pagination

### DIFF
--- a/changelog/v0.21.9/fix-docs-gen-ratelimit-issue.yaml
+++ b/changelog/v0.21.9/fix-docs-gen-ratelimit-issue.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/4974
+    resolvesIssue: false
+    description: Start querying github paginated API at page 1, rather than page 0.

--- a/githubutils/repo.go
+++ b/githubutils/repo.go
@@ -36,6 +36,7 @@ const (
 	CONTENT_TYPE_DIRECTORY = "dir"
 
 	MAX_GITHUB_RELEASES_PER_PAGE = 100
+	MIN_GITHUB_PAGE_NUM          = 1
 )
 
 func GetGithubToken() (string, error) {
@@ -144,7 +145,7 @@ func GetAllRepoReleases(ctx context.Context, client *github.Client, owner, repo 
 
 func GetAllRepoReleasesWithMax(ctx context.Context, client *github.Client, owner, repo string, maxReleases int) ([]*github.RepositoryRelease, error) {
 	var allReleases []*github.RepositoryRelease
-	for i := 1; len(allReleases) < maxReleases; i += 1 {
+	for i := MIN_GITHUB_PAGE_NUM; len(allReleases) < maxReleases; i += 1 {
 		releases, _, err := client.Repositories.ListReleases(ctx, owner, repo, &github.ListOptions{
 			Page:    i,
 			PerPage: MAX_GITHUB_RELEASES_PER_PAGE,

--- a/githubutils/repo.go
+++ b/githubutils/repo.go
@@ -144,7 +144,7 @@ func GetAllRepoReleases(ctx context.Context, client *github.Client, owner, repo 
 
 func GetAllRepoReleasesWithMax(ctx context.Context, client *github.Client, owner, repo string, maxReleases int) ([]*github.RepositoryRelease, error) {
 	var allReleases []*github.RepositoryRelease
-	for i := 0; len(allReleases) < maxReleases; i += 1 {
+	for i := 1; len(allReleases) < maxReleases; i += 1 {
 		releases, _, err := client.Repositories.ListReleases(ctx, owner, repo, &github.ListOptions{
 			Page:    i,
 			PerPage: MAX_GITHUB_RELEASES_PER_PAGE,


### PR DESCRIPTION
Github API Paginations starts at page 1: https://docs.github.com/en/rest/guides/traversing-with-pagination#navigating-through-the-pages. We should start querying at page 1 so we don't get duplicate results for page 0 and page 1.