### PR TITLE
Create vulnerability Github Issues on Trivy scan

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - uses: GoogleCloudPlatform/github-actions/setup-gcloud@0.2.1
+    - uses: GoogleCloudPlatform/github-actions/setup-gcloud@v0.2.1
       with:
         version: '290.0.1'
         project_id: ${{ secrets.GCP_PROJECT_ID }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -20,7 +20,6 @@ jobs:
         fetch-depth: 0
     - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
       with:
-        version: '290.0.1'
         project_id: ${{ secrets.GCP_PROJECT_ID }}
         service_account_key: ${{ secrets.GCP_SA_KEY }}
         export_default_credentials: true

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -18,8 +18,9 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+    - uses: GoogleCloudPlatform/github-actions/setup-gcloud@0.2.1
       with:
+        version: '290.0.1'
         project_id: ${{ secrets.GCP_PROJECT_ID }}
         service_account_key: ${{ secrets.GCP_SA_KEY }}
         export_default_credentials: true

--- a/changelog/v0.21.11/security-scan-create-github-issue.yaml
+++ b/changelog/v0.21.11/security-scan-create-github-issue.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/gloo/issues/5048
+    resolvesIssue: false
+    description: >
+      Adds option to Security Scanner to create github issues for each image that a vulnerability is found in.
+      If an issue already exists for that image, it will update the issue with the most recent vulnerability scan results.

--- a/githubutils/repo_test.go
+++ b/githubutils/repo_test.go
@@ -17,5 +17,6 @@ var _ = Describe("repo utils", func() {
 		sha, err := githubutils.GetCommitForTag("solo-io", "solo-projects", "v1.6.0", true)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(sha).To(Equal("7110f444371f7ea7b18ed4380438709492d02bb8"))
+
 	})
 })

--- a/githubutils/repo_test.go
+++ b/githubutils/repo_test.go
@@ -17,6 +17,5 @@ var _ = Describe("repo utils", func() {
 		sha, err := githubutils.GetCommitForTag("solo-io", "solo-projects", "v1.6.0", true)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(sha).To(Equal("7110f444371f7ea7b18ed4380438709492d02bb8"))
-
 	})
 })

--- a/osutils/executils/exec.go
+++ b/osutils/executils/exec.go
@@ -1,0 +1,19 @@
+package executils
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// Runs cmd.CombinedOutput and returns the status code of the run
+func CombinedOutputWithStatus(cmd *exec.Cmd) ([]byte, int, error) {
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+				return out, status.ExitStatus(), err
+			}
+		}
+	}
+	return out, 0, err
+}

--- a/securityscanutils/README.md
+++ b/securityscanutils/README.md
@@ -52,6 +52,8 @@ func main() {
                     // endpoint, e.g. https://github.com/solo-io/gloo/security/code-scanning
                     // read more here: https://docs.github.com/en/rest/reference/code-scanning
 					UploadCodeScanToGithub: true,
+					// Opens/Updates Github Issue for each image a vulnerability is found in
+                    CreateGithubIssuePerImageVulnerability: true,
 				},
 			},
 		},

--- a/securityscanutils/trivy_templates.go
+++ b/securityscanutils/trivy_templates.go
@@ -13,6 +13,8 @@ const MarkdownTrivyTemplate = `{{- if . }}
 
 No Vulnerabilities Found for {{.Target}}
 {{- else }}
+Vulnerabilities Listed for {{.Target}}
+
 Vulnerability ID|Package|Severity|Installed Version|Fixed Version|Reference
 ---|---|---|---|---|---
 {{- range .Vulnerabilities }}


### PR DESCRIPTION
Adds option to Security Scanner to create github issues for each image that a vulnerability is found in.
      If an issue already exists for that image, it will update the issue with the most recent vulnerability scan results. 

This is especially useful for reporting vulnerabilities in private repositories, because the "Code scanning results" tab for private repositories is a paid-feature.

Example generated issue: https://github.com/solo-io/solo-projects/issues/2467