### PR TITLE
Support Trivy Scan Retries

### DIFF
--- a/changelog/v0.21.16/trivy-retries.yaml
+++ b/changelog/v0.21.16/trivy-retries.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      Support retries in Trivy scan.
+      This is an attempt to handle cases where a network connection failure causes
+      a Trivy scan to fail. Since the SecurityScan executes as a bulk job, we want
+      to ensure that transient failures do not cause the entire job to fail.

--- a/securityscanutils/securityscan.go
+++ b/securityscanutils/securityscan.go
@@ -7,21 +7,22 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"os"
 	"os/exec"
 	"path"
 	"strconv"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
+
 	"github.com/google/go-github/v32/github"
 	"github.com/solo-io/go-utils/osutils/executils"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/imroc/req"
 	"github.com/rotisserie/eris"
 	"github.com/solo-io/go-utils/githubutils"
 	"github.com/solo-io/go-utils/log"
-	"github.com/solo-io/go-utils/osutils"
 )
 
 type SecurityScanner struct {
@@ -110,14 +111,18 @@ func (s *SecurityScanner) GenerateSecurityScans(ctx context.Context) error {
 		os.Remove(markdownTplFile)
 		os.Remove(sarifTplFile)
 	}()
+
 	for _, repo := range s.Repos {
 		opts := repo.Opts
-		allReleases, err := githubutils.GetAllRepoReleases(ctx, s.githubClient, repo.Owner, repo.Repo)
+
+		// This predicate filters releases so we only perform scans on the images that are relevant to the repo
+		repoReleasePredicate := getReleasePredicateForSecurityScan(opts.VersionConstraint)
+		maxReleasesToScan := math.MaxInt32
+		filteredReleases, err := githubutils.GetRepoReleasesWithPredicateAndMax(ctx, s.githubClient, repo.Owner, repo.Repo, repoReleasePredicate, maxReleasesToScan)
 		if err != nil {
 			return eris.Wrapf(err, "unable to fetch all github releases for github.com/%s/%s", repo.Owner, repo.Repo)
 		}
-		// Filter releases by version constraint provided
-		filteredReleases := githubutils.FilterReleases(allReleases, opts.VersionConstraint)
+
 		githubutils.SortReleasesBySemver(filteredReleases)
 		if repo.Opts.CreateGithubIssuePerVersion {
 			repo.allGithubIssues, err = githubutils.GetAllIssues(ctx, s.githubClient, repo.Owner, repo.Repo, &github.IssueListByRepoOptions{
@@ -244,6 +249,43 @@ func (r *SecurityScanRepo) GetImagesToScan(versionToScan *semver.Version) ([]str
 	return imagesToScan, nil
 }
 
+func getReleasePredicateForSecurityScan(versionConstraint *semver.Constraints) *SecurityScanRepositoryReleasePredicate {
+	return &SecurityScanRepositoryReleasePredicate{
+		versionConstraint: versionConstraint,
+	}
+}
+
+// The SecurityScanRepositoryReleasePredicate is responsible for defining which
+// github.RepositoryRelease artifacts should be included in the bulk security scan
+// At the moment, the two requirements are that:
+// 1. The release is not a pre-release or draft
+// 2. The release matches the configured version constraint
+type SecurityScanRepositoryReleasePredicate struct {
+	versionConstraint *semver.Constraints
+}
+
+func (s *SecurityScanRepositoryReleasePredicate) Apply(release *github.RepositoryRelease) bool {
+	if release.GetPrerelease() || release.GetDraft() {
+		// Do not include pre-releases or drafts
+		return false
+	}
+
+	versionToTest, err := semver.NewVersion(release.GetTagName())
+	if err != nil {
+		// If we are unable to parse the release version, we do not include it in the filtered list
+		log.Warnf("unable to parse release version %s", release.GetTagName())
+		return false
+	}
+
+	if !s.versionConstraint.Check(versionToTest) {
+		// If the release version does not pass the version constraint, do not include
+		return false
+	}
+
+	// If all checks have passed, include the release
+	return true
+}
+
 // Runs trivy scan command
 // Returns (trivy scan ran successfully, vulnerabilities found, error running trivy scan)
 func RunTrivyScan(image, version, templateFile, output string) (bool, bool, error) {
@@ -261,7 +303,13 @@ func RunTrivyScan(image, version, templateFile, output string) (bool, bool, erro
 		"--output", output,
 		image}
 	cmd := exec.Command("trivy", args...)
-	out, statusCode, err := executils.CombinedOutputWithStatus(cmd)
+
+	// Execute the trivy scan, with 3 retries
+	// We noticed flakes when executing the trivy scan and the easiest solution
+	// is to just perform a retry. If this does not resolve the issue, we should
+	// investigate a more robust solution.
+	out, statusCode, err := executeTrivyScanWithRetries(cmd, 3)
+
 	// Check if a vulnerability has been found
 	vulnFound := statusCode == VulnerabilityFoundStatusCode
 	// err will be non-nil if there is a non-zero status code
@@ -272,6 +320,10 @@ func RunTrivyScan(image, version, templateFile, output string) (bool, bool, erro
 		_ = os.Remove(output)
 		// swallow error if image is not found error, so that we can continue scanning releases
 		// even if some releases failed and we didn't publish images for those releases
+		// this error used to happen if a release was a pre-release and therefore images
+		// weren't pushed to the container registry.
+		// we have since filtered out non-release images from being scanned so this warning
+		// shouldn't occur, but leaving here in case there was another edge case we missed
 		if IsImageNotFoundErr(string(out)) {
 			log.Warnf("image %s not found for version %s", image, version)
 			return false, false, nil
@@ -279,6 +331,33 @@ func RunTrivyScan(image, version, templateFile, output string) (bool, bool, erro
 		return false, false, eris.Wrapf(err, "error running trivy scan on image %s, version %s, Logs: \n%s", image, version, string(out))
 	}
 	return true, vulnFound, nil
+}
+
+func executeTrivyScanWithRetries(trivyScanCmd *exec.Cmd, numberOfRetries int) ([]byte, int, error) {
+	remainingRetries := numberOfRetries
+
+	var (
+		out        []byte
+		statusCode int
+		err        error
+	)
+
+	for remainingRetries > 0 {
+		out, statusCode, err = executils.CombinedOutputWithStatus(trivyScanCmd)
+
+		// If there is no error, don't retry
+		if err == nil {
+			return out, statusCode, err
+		}
+
+		// If there is no image, don't retry
+		if IsImageNotFoundErr(string(out)) {
+			return out, statusCode, err
+		}
+		// decrement the remaining retries
+		remainingRetries -= 1
+	}
+	return out, statusCode, err
 }
 
 type SarifMetadata struct {
@@ -293,7 +372,8 @@ func (r *SecurityScanRepo) UploadSecurityScanToGithub(fileName, versionTag strin
 	if err != nil {
 		return err
 	}
-	githubToken, err := osutils.GetEnvE("GITHUB_TOKEN")
+
+	githubToken, err := githubutils.GetGithubToken()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Introduce a RepositoryReleasesPredicate, allowing clients to define the filter behavior for github repository releases. Ideally, we could configure this in the API request, but unfortunately that is not supported at the moment.
- Add retries to our Trivy scanning logic. We noticed a flake in a previous run: https://github.com/solo-io/gloo/runs/3280618311?check_suite_focus=true, that we hope will be resolved by adding some retries, though we are not sure.