### PR TITLE
Publish ScanAggregate to slack

### DIFF
--- a/changelog/v0.21.20/security-scan-slack-notification.yaml
+++ b/changelog/v0.21.20/security-scan-slack-notification.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Notify Slack repo when security scan completes


### PR DESCRIPTION
When a security scan completes, publish the ScanAggregate (metadata about the scan) to slack

# Context
I had initially attempted to make the scanner more event driven, so that the scanner produced events and we could have a set of subscribers that consumed them. This would make it easier to separate the behavior of how to execute a scan from how to respond to scan events. I had started the work on this branch: https://github.com/solo-io/go-utils/tree/security-scan-notifier. I decided to move away from it, since it was a little too much work for this type of change. If in the future there are more changes to scan eventing, we may want to reconsider using it.