### PR TITLE
Fix gen-security-scan-md command.

### DIFF
--- a/changelog/v0.21.21/security-scan-cli-fix.yaml
+++ b/changelog/v0.21.21/security-scan-cli-fix.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Fix gen-security-scan-md command of new security scan CLI to properly infer image names.

--- a/securityscanutils/security_scan_command.go
+++ b/securityscanutils/security_scan_command.go
@@ -266,6 +266,8 @@ func scanRepoImages(opts *options) error {
 func generateSecurityScanForRepo(opts *options) error {
 	// Initialize Auth
 	client, err := githubutils.GetClient(opts.ctx)
+	// Sets the opts.allImages value, which we need for this command
+	readImageVersionConstraintsFile(opts)
 	if err != nil {
 		return err
 	}
@@ -342,6 +344,8 @@ func BuildSecurityScanReportForRepo(tags []string, opts *options) error {
 }
 
 func printImageReportForRepo(tag string, opts *options) error {
+
+	fmt.Printf("**number of images for tag %s: %d**\n\n", tag, len(opts.allImages))
 	for _, image := range opts.allImages {
 		fmt.Printf("**%s %s image**\n\n", opts.targetRepoWritten, image)
 		url := "https://storage.googleapis.com/solo-gloo-security-scans/" + opts.targetRepo + "/" + tag + "/" + image + "_cve_report.docgen"

--- a/securityscanutils/security_scan_command.go
+++ b/securityscanutils/security_scan_command.go
@@ -344,8 +344,6 @@ func BuildSecurityScanReportForRepo(tags []string, opts *options) error {
 }
 
 func printImageReportForRepo(tag string, opts *options) error {
-
-	fmt.Printf("**number of images for tag %s: %d**\n\n", tag, len(opts.allImages))
 	for _, image := range opts.allImages {
 		fmt.Printf("**%s %s image**\n\n", opts.targetRepoWritten, image)
 		url := "https://storage.googleapis.com/solo-gloo-security-scans/" + opts.targetRepo + "/" + tag + "/" + image + "_cve_report.docgen"


### PR DESCRIPTION
1-liner fix to the scan docgen command. It needed to read in the inputted image file to get a list of images to examine. It's still a little naive since it doesn't consider version constraints in the same way the main scanning file does, but that's a nit that can be dealt with later.