### PR TITLE
Do not create empty Github issues on trivy scans with no vulnerabilities

### DIFF
--- a/changelog/v0.21.22/avoid-empty-gh-issue.yaml
+++ b/changelog/v0.21.22/avoid-empty-gh-issue.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/2739
+    description: Do not create empty Github issues on trivy scans with no vulnerabilities

--- a/securityscanutils/securityscan.go
+++ b/securityscanutils/securityscan.go
@@ -189,10 +189,12 @@ func (r *SecurityScanRepo) RunMarkdownScan(ctx context.Context, client *github.C
 	// Create / Update Github issue for the repo if a vulnerability is found
 	// and CreateGithubIssuePerVersion is set to true
 	if r.Opts.CreateGithubIssuePerVersion {
-		err = r.CreateUpdateVulnerabilityIssue(ctx, client, version, vulnerabilityMd)
-		if err != nil {
-			return err
+		if vulnerabilityMd == "" {
+			// We did not find vulnerabilities in any of the images for this version
+			// do not create an empty github issue
+			return nil
 		}
+		return r.CreateUpdateVulnerabilityIssue(ctx, client, version, vulnerabilityMd)
 	}
 	return nil
 }


### PR DESCRIPTION
When the security scanner finds no vulnerabilities for a version, it still creates a github issue:

https://github.com/solo-io/solo-projects/issues/2790

Do not create an issue if it is empty.

BOT NOTES: 
resolves https://github.com/solo-io/solo-projects/issues/2739