### PR TITLE
Trivy Scanning: Scan all images and only create issue for latest patch release

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -47,7 +47,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.CLOUDBUILD_GITHUB_TOKEN }}
       run: |
         go install -v github.com/onsi/ginkgo/ginkgo@v1.16.5 && export PATH=$PATH:$(go env GOPATH)/bin/
-        ginkgo  -r   -p   -failFast   -randomizeSuites   -randomizeAllSpecs   -skipPackage=./installutils/kubeinstall,./debugutils/test
+        ginkgo -r -failFast -randomizeSuites -randomizeAllSpecs -skipPackage=./installutils/kubeinstall,./debugutils/test
     - uses: testspace-com/setup-testspace@v1
       with:
         domain: solo-io.testspace.com

--- a/changelog/v0.21.27/trivy-github-issue-per-minor.yaml
+++ b/changelog/v0.21.27/trivy-github-issue-per-minor.yaml
@@ -1,0 +1,15 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/go-utils/issues/469
+    resolvesIssue: false
+    description: >
+      Ensure the SecurityScanner scans all images for a set of minor versions.
+      Previously, the scanner would only scan the latest patch release, which would cause docs which depend
+      on these scans (as Gloo Edge does) to show empty scans.
+  - type: FIX
+    issueLink: https://github.com/solo-io/go-utils/issues/478
+    resolvesIssue: true
+    description: >
+      Expose a new option 'CreateGithubIssueForLatestPatchVersion', which when enabled, will ensure that the
+      SecurityScanner only creates Github issues to track the latest patch version as opposed to creating
+      an issue for every version (which it has historically done)

--- a/githubutils/repo.go
+++ b/githubutils/repo.go
@@ -156,6 +156,13 @@ func (a *AllReleasesPredicate) Apply(_ *github.RepositoryRelease) bool {
 	return true
 }
 
+type NoReleasesPredicate struct {
+}
+
+func (a *NoReleasesPredicate) Apply(_ *github.RepositoryRelease) bool {
+	return false
+}
+
 func GetAllRepoReleases(ctx context.Context, client *github.Client, owner, repo string) ([]*github.RepositoryRelease, error) {
 	return GetAllRepoReleasesWithMax(ctx, client, owner, repo, math.MaxInt32)
 }

--- a/securityscanutils/github_writer.go
+++ b/securityscanutils/github_writer.go
@@ -1,0 +1,116 @@
+package securityscanutils
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/google/go-github/v32/github"
+	"github.com/rotisserie/eris"
+	"github.com/solo-io/go-utils/githubutils"
+)
+
+type GithubRepo struct {
+	RepoName string
+	Owner    string
+}
+
+func (r GithubRepo) Address() string {
+	return fmt.Sprintf("github.com/%s/%s", r.Owner, r.RepoName)
+}
+
+type GithubIssueWriter struct {
+	// The details about the Github repository
+	repo GithubRepo
+
+	// The client used to write the issues
+	client *github.Client
+
+	// The RepositoryReleasePredicate used to determine if a vulnerability
+	// associated with a certain release should be uploaded to GitHub
+	createGithubIssuePredicate githubutils.RepositoryReleasePredicate
+
+	// A local cache of all existing GitHub issues
+	// Used to ensure that we are updating existing issues that were created by previous scans
+	allGithubIssues []*github.Issue
+}
+
+func NewGithubIssueWriter(repo GithubRepo, client *github.Client, issuePredicate githubutils.RepositoryReleasePredicate) *GithubIssueWriter {
+	return &GithubIssueWriter{
+		repo:                       repo,
+		client:                     client,
+		createGithubIssuePredicate: issuePredicate,
+		allGithubIssues:            nil, // initially nil, we'll lazy load these
+	}
+}
+
+// Labels that are applied to github issues that security scan generates
+var labels = []string{"trivy", "vulnerability"}
+
+func (g *GithubIssueWriter) getAllGithubIssues(ctx context.Context) ([]*github.Issue, error) {
+	if g.allGithubIssues != nil {
+		return g.allGithubIssues, nil
+	}
+
+	issues, err := githubutils.GetAllIssues(ctx, g.client, g.repo.Owner, g.repo.RepoName, &github.IssueListByRepoOptions{
+		State:  "open",
+		Labels: labels,
+	})
+	if err != nil {
+		return nil, eris.Wrapf(err, "error fetching all issues from %s", g.repo.Address())
+	}
+	g.allGithubIssues = issues
+	return g.allGithubIssues, nil
+}
+
+// Creates/Updates a Github Issue per image
+// The github issue will have the markdown table report of the image's vulnerabilities
+// example: https://github.com/solo-io/solo-projects/issues/2458
+func (g *GithubIssueWriter) CreateUpdateVulnerabilityIssue(ctx context.Context, release *github.RepositoryRelease, vulnerabilityMarkdown string) error {
+	if !g.shouldWriteIssue(release) {
+		// The GithubIssueWriter can be configured to only write issues for certain releases
+		return nil
+	}
+
+	// We can swallow the error here, any releases with improper tag names
+	// will not be included in the filtered list
+	versionToScan, _ := semver.NewVersion(release.GetTagName())
+
+	issueTitle := fmt.Sprintf("Security Alert: %s", versionToScan.String())
+	issueRequest := &github.IssueRequest{
+		Title:  github.String(issueTitle),
+		Body:   github.String(vulnerabilityMarkdown),
+		Labels: &labels,
+	}
+	createNewIssue := true
+
+	issues, err := g.getAllGithubIssues(ctx)
+	if err != nil {
+		return eris.Wrapf(err, "failed to get all github issues for repo")
+	}
+
+	// TODO - We could avoid iterating over the issues by indexing them by Title
+	for _, issue := range issues {
+		// If issue already exists, update existing issue with new security scan
+		if issue.GetTitle() == issueTitle {
+			// Only create new issue if issue does not already exist
+			createNewIssue = false
+			err := githubutils.UpdateIssue(ctx, g.client, g.repo.Owner, g.repo.RepoName, issue.GetNumber(), issueRequest)
+			if err != nil {
+				return eris.Wrapf(err, "error updating issue with issue request %+v", issueRequest)
+			}
+			break
+		}
+	}
+	if createNewIssue {
+		_, err := githubutils.CreateIssue(ctx, g.client, g.repo.Owner, g.repo.RepoName, issueRequest)
+		if err != nil {
+			return eris.Wrapf(err, "error creating issue with issue request %+v", issueRequest)
+		}
+	}
+	return nil
+}
+
+func (g *GithubIssueWriter) shouldWriteIssue(release *github.RepositoryRelease) bool {
+	return g.createGithubIssuePredicate.Apply(release)
+}

--- a/securityscanutils/github_writer.go
+++ b/securityscanutils/github_writer.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/solo-io/go-utils/contextutils"
+
 	"github.com/Masterminds/semver/v3"
 	"github.com/google/go-github/v32/github"
 	"github.com/rotisserie/eris"
@@ -73,6 +75,8 @@ func (g *GithubIssueWriter) getAllGithubIssues(ctx context.Context) ([]*github.I
 // The github issue will have the markdown table report of the image's vulnerabilities
 // example: https://github.com/solo-io/solo-projects/issues/2458
 func (g *GithubIssueWriter) CreateUpdateVulnerabilityIssue(ctx context.Context, release *github.RepositoryRelease, vulnerabilityMarkdown string) error {
+	logger := contextutils.LoggerFrom(ctx)
+
 	if vulnerabilityMarkdown == "" {
 		// There we no vulnerabilities discovered for this release
 		// do not create an empty github issue
@@ -80,6 +84,7 @@ func (g *GithubIssueWriter) CreateUpdateVulnerabilityIssue(ctx context.Context, 
 	}
 
 	if !g.shouldWriteIssue(release) {
+		logger.Debugf("GithubIssueWriter skipping release %s", release.GetTagName())
 		// The GithubIssueWriter can be configured to only write issues for certain releases
 		return nil
 	}
@@ -95,6 +100,7 @@ func (g *GithubIssueWriter) CreateUpdateVulnerabilityIssue(ctx context.Context, 
 		Labels: &labels,
 	}
 	createNewIssue := true
+	logger.Debugf("GithubIssueWriter attempting to create or update issue: %s", issueTitle)
 
 	issues, err := g.getAllGithubIssues(ctx)
 	if err != nil {

--- a/securityscanutils/predicate.go
+++ b/securityscanutils/predicate.go
@@ -3,20 +3,27 @@ package securityscanutils
 import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/google/go-github/v32/github"
+	"github.com/solo-io/go-utils/githubutils"
 	"github.com/solo-io/go-utils/log"
 	"github.com/solo-io/go-utils/versionutils"
 )
 
-// The SecurityScanRepositoryReleasePredicate is responsible for defining which
+// The securityScanRepositoryReleasePredicate is responsible for defining which
 // github.RepositoryRelease artifacts should be included in the bulk security scan
 // At the moment, the two requirements are that:
 // 1. The release is not a pre-release or draft
 // 2. The release matches the configured version constraint
-type SecurityScanRepositoryReleasePredicate struct {
+type securityScanRepositoryReleasePredicate struct {
 	versionConstraint *semver.Constraints
 }
 
-func (s *SecurityScanRepositoryReleasePredicate) Apply(release *github.RepositoryRelease) bool {
+func NewSecurityScanRepositoryReleasePredicate(constraint *semver.Constraints) *securityScanRepositoryReleasePredicate {
+	return &securityScanRepositoryReleasePredicate{
+		versionConstraint: constraint,
+	}
+}
+
+func (s *securityScanRepositoryReleasePredicate) Apply(release *github.RepositoryRelease) bool {
 	if release.GetPrerelease() || release.GetDraft() {
 		// Do not include pre-releases or drafts
 		return false
@@ -38,14 +45,19 @@ func (s *SecurityScanRepositoryReleasePredicate) Apply(release *github.Repositor
 	return true
 }
 
-type LTSOnlyRepositoryReleasePredicate struct {
-	releaseSet []*github.RepositoryRelease
+// The latestPatchRepositoryReleasePredicate returns true if a provided RepositoryRelease
+// is the latest patch release on a long-term support (LTS) branch
+// For example: The latest patch release of v1.0.0, v1.0.1, v1.0.2 is v1.0.2 (https://semver.org/)
+type latestPatchRepositoryReleasePredicate struct {
+	releasesByTagName map[string]*github.RepositoryRelease
 }
 
-func NewLTSOnlyRepositoryReleasePredicate(releases []*github.RepositoryRelease) *LTSOnlyRepositoryReleasePredicate {
+func NewLatestPatchRepositoryReleasePredicate(releases []*github.RepositoryRelease) *latestPatchRepositoryReleasePredicate {
+	githubutils.SortReleasesBySemver(releases)
+
 	// We could use maxint but we dont really care
 	// as we can just check if major minor changed
-	var ltsOnlyReleases []*github.RepositoryRelease
+	latestPatchReleasesByTagName := make(map[string]*github.RepositoryRelease)
 
 	recentMajor := -1
 	recentMinor := -1
@@ -61,20 +73,15 @@ func NewLTSOnlyRepositoryReleasePredicate(releases []*github.RepositoryRelease) 
 		// This is the largest patch release
 		recentMajor = version.Major
 		recentMinor = version.Minor
-		ltsOnlyReleases = append(ltsOnlyReleases, release)
+		latestPatchReleasesByTagName[release.GetTagName()] = release
 	}
 
-	return &LTSOnlyRepositoryReleasePredicate{
-		releaseSet: ltsOnlyReleases,
+	return &latestPatchRepositoryReleasePredicate{
+		releasesByTagName: latestPatchReleasesByTagName,
 	}
 }
 
-func (s *LTSOnlyRepositoryReleasePredicate) Apply(release *github.RepositoryRelease) bool {
-	for _, r := range s.releaseSet {
-		if r.Name == release.Name {
-			return true
-		}
-	}
-
-	return false
+func (s *latestPatchRepositoryReleasePredicate) Apply(release *github.RepositoryRelease) bool {
+	_, ok := s.releasesByTagName[release.GetTagName()]
+	return ok
 }

--- a/securityscanutils/predicate.go
+++ b/securityscanutils/predicate.go
@@ -1,0 +1,80 @@
+package securityscanutils
+
+import (
+	"github.com/Masterminds/semver/v3"
+	"github.com/google/go-github/v32/github"
+	"github.com/solo-io/go-utils/log"
+	"github.com/solo-io/go-utils/versionutils"
+)
+
+// The SecurityScanRepositoryReleasePredicate is responsible for defining which
+// github.RepositoryRelease artifacts should be included in the bulk security scan
+// At the moment, the two requirements are that:
+// 1. The release is not a pre-release or draft
+// 2. The release matches the configured version constraint
+type SecurityScanRepositoryReleasePredicate struct {
+	versionConstraint *semver.Constraints
+}
+
+func (s *SecurityScanRepositoryReleasePredicate) Apply(release *github.RepositoryRelease) bool {
+	if release.GetPrerelease() || release.GetDraft() {
+		// Do not include pre-releases or drafts
+		return false
+	}
+
+	versionToTest, err := semver.NewVersion(release.GetTagName())
+	if err != nil {
+		// If we are unable to parse the release version, we do not include it in the filtered list
+		log.Warnf("unable to parse release version %s", release.GetTagName())
+		return false
+	}
+
+	if !s.versionConstraint.Check(versionToTest) {
+		// If the release version does not pass the version constraint, do not include
+		return false
+	}
+
+	// If all checks have passed, include the release
+	return true
+}
+
+type LTSOnlyRepositoryReleasePredicate struct {
+	releaseSet []*github.RepositoryRelease
+}
+
+func NewLTSOnlyRepositoryReleasePredicate(releases []*github.RepositoryRelease) *LTSOnlyRepositoryReleasePredicate {
+	// We could use maxint but we dont really care
+	// as we can just check if major minor changed
+	var ltsOnlyReleases []*github.RepositoryRelease
+
+	recentMajor := -1
+	recentMinor := -1
+	for _, release := range releases {
+		version, err := versionutils.ParseVersion(release.GetTagName())
+		if err != nil {
+			continue
+		}
+		if version.Major == recentMajor && version.Minor == recentMinor {
+			continue
+		}
+
+		// This is the largest patch release
+		recentMajor = version.Major
+		recentMinor = version.Minor
+		ltsOnlyReleases = append(ltsOnlyReleases, release)
+	}
+
+	return &LTSOnlyRepositoryReleasePredicate{
+		releaseSet: ltsOnlyReleases,
+	}
+}
+
+func (s *LTSOnlyRepositoryReleasePredicate) Apply(release *github.RepositoryRelease) bool {
+	for _, r := range s.releaseSet {
+		if r.Name == release.Name {
+			return true
+		}
+	}
+
+	return false
+}

--- a/securityscanutils/predicate_test.go
+++ b/securityscanutils/predicate_test.go
@@ -1,0 +1,94 @@
+package securityscanutils_test
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/google/go-github/v32/github"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"github.com/solo-io/go-utils/githubutils"
+	"github.com/solo-io/go-utils/securityscanutils"
+)
+
+var _ = Describe("Predicate", func() {
+
+	Context("securityScanRepositoryReleasePredicate", func() {
+
+		var (
+			releasePredicate githubutils.RepositoryReleasePredicate
+		)
+
+		BeforeEach(func() {
+			twoPlusConstraint, err := semver.NewConstraint(fmt.Sprintf(">= %s", "v2.0.0"))
+			Expect(err).NotTo(HaveOccurred())
+
+			releasePredicate = securityscanutils.NewSecurityScanRepositoryReleasePredicate(twoPlusConstraint)
+		})
+
+		DescribeTable(
+			"Returns true/false based on release properties",
+			func(release *github.RepositoryRelease, expectedResult bool) {
+				Expect(releasePredicate.Apply(release)).To(Equal(expectedResult))
+			},
+			Entry("release is draft", &github.RepositoryRelease{
+				Draft: github.Bool(true),
+			}, false),
+			Entry("release is pre-release", &github.RepositoryRelease{
+				Prerelease: github.Bool(true),
+			}, false),
+			Entry("release tag does not respect semver", &github.RepositoryRelease{
+				TagName: github.String("non-semver-tag-name"),
+			}, false),
+			Entry("release tag does not pass version constraint", &github.RepositoryRelease{
+				TagName: github.String("v1.0.0"),
+			}, false),
+			Entry("release tag does pass version constraint", &github.RepositoryRelease{
+				TagName: github.String("v2.0.1"),
+			}, true),
+		)
+
+	})
+
+	Context("latestPatchRepositoryReleasePredicate", func() {
+
+		var (
+			releasePredicate githubutils.RepositoryReleasePredicate
+		)
+
+		BeforeEach(func() {
+			releaseSet := []*github.RepositoryRelease{
+				{
+					TagName: github.String("v1.0.1"),
+				},
+				{
+					TagName: github.String("v1.0.2"),
+				},
+				{
+					TagName: github.String("v1.0.3"),
+				},
+			}
+
+			releasePredicate = securityscanutils.NewLatestPatchRepositoryReleasePredicate(releaseSet)
+		})
+
+		DescribeTable(
+			"Returns true/false based on release properties",
+			func(release *github.RepositoryRelease, expectedResult bool) {
+				Expect(releasePredicate.Apply(release)).To(Equal(expectedResult))
+			},
+			Entry("release is not in release set", &github.RepositoryRelease{
+				TagName: github.String("v3.0.0"), // not in the original release set
+			}, false),
+			Entry("release is not latest patch release", &github.RepositoryRelease{
+				TagName: github.String("v1.0.1"),
+			}, false),
+			Entry("release is latest patch release", &github.RepositoryRelease{
+				TagName: github.String("v1.0.3"),
+			}, true),
+		)
+
+	})
+
+})

--- a/securityscanutils/securityscan.go
+++ b/securityscanutils/securityscan.go
@@ -198,7 +198,9 @@ func (s *SecurityScanner) initializeRepoConfiguration(ctx context.Context, repo 
 	}
 
 	// Set the Predicate used to filter releases we wish to scan
-	repo.scanReleasePredicate = getReleasePredicateForSecurityScan(repo.Opts.VersionConstraint)
+	repo.scanReleasePredicate = &SecurityScanRepositoryReleasePredicate{
+		versionConstraint: repoOptions.VersionConstraint,
+	}
 
 	// Default to creating a GitHub issue for all releases
 	repo.createGithubIssuePredicate = &githubutils.AllReleasesPredicate{}
@@ -206,7 +208,6 @@ func (s *SecurityScanner) initializeRepoConfiguration(ctx context.Context, repo 
 	// TODO Add logic to handle instantiating a Predicate that returns true only if Release matches latest LTS
 
 	return nil
-
 }
 
 func (r *SecurityScanRepo) RunMarkdownScan(ctx context.Context, client *github.Client, release *github.RepositoryRelease, markdownTplFile string) error {
@@ -322,12 +323,6 @@ func (r *SecurityScanRepo) GetImagesToScan(versionToScan *semver.Version) ([]str
 		return nil, eris.Errorf("version %s matched no constraints and has no images to scan", versionToScan.String())
 	}
 	return stringutils.Keys(imagesToScan), nil
-}
-
-func getReleasePredicateForSecurityScan(versionConstraint *semver.Constraints) *SecurityScanRepositoryReleasePredicate {
-	return &SecurityScanRepositoryReleasePredicate{
-		versionConstraint: versionConstraint,
-	}
 }
 
 // The SecurityScanRepositoryReleasePredicate is responsible for defining which

--- a/securityscanutils/securityscan.go
+++ b/securityscanutils/securityscan.go
@@ -202,8 +202,12 @@ func (s *SecurityScanner) initializeRepoConfiguration(ctx context.Context, repo 
 		versionConstraint: repoOptions.VersionConstraint,
 	}
 
-	// Default to creating a GitHub issue for all releases
-	repo.createGithubIssuePredicate = &githubutils.AllReleasesPredicate{}
+	// Default to not creating any issues
+	repo.createGithubIssuePredicate = &githubutils.NoReleasesPredicate{}
+	if repoOptions.CreateGithubIssuePerVersion {
+		// Create Github issue for all releases, if configured
+		repo.createGithubIssuePredicate = &githubutils.AllReleasesPredicate{}
+	}
 
 	// TODO Add logic to handle instantiating a Predicate that returns true only if Release matches latest LTS
 

--- a/securityscanutils/trivy_scanner.go
+++ b/securityscanutils/trivy_scanner.go
@@ -1,0 +1,105 @@
+package securityscanutils
+
+import (
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/rotisserie/eris"
+	"github.com/solo-io/go-utils/log"
+	"github.com/solo-io/go-utils/osutils/executils"
+)
+
+// Status code returned by Trivy if a vulnerability is found
+const VulnerabilityFoundStatusCode = 52
+
+// Runs trivy scan command
+// Returns (trivy scan ran successfully, vulnerabilities found, error running trivy scan)
+func RunTrivyScan(image, version, templateFile, output string) (bool, bool, error) {
+	// Ensure Trivy is installed and on PATH
+	_, err := exec.LookPath("trivy")
+	if err != nil {
+		return false, false, eris.Wrap(err, "trivy is not on PATH, make sure that the trivy v0.18 is installed and on PATH")
+	}
+	trivyScanArgs := []string{"image",
+		// Trivy will return a specific status code (which we have specified) if a vulnerability is found
+		"--exit-code", strconv.Itoa(VulnerabilityFoundStatusCode),
+		"--severity", "HIGH,CRITICAL",
+		"--format", "template",
+		"--template", "@" + templateFile,
+		"--output", output,
+		image}
+	// Execute the trivy scan, with retries and sleep's between each retry
+	// This can occur due to connectivity issues or epehemeral issues with
+	// the registery. For example sometimes quay has issues providing a given layer
+	// This leads to a total wait time of up to 110 seconds outside of the base
+	// operation. This timing is in the same ballpark as what k8s finds sensible
+	out, statusCode, err := executeTrivyScanWithRetries(
+		trivyScanArgs, 5,
+		func(attempt int) { time.Sleep(time.Duration((attempt^2)*2) * time.Second) },
+	)
+
+	// Check if a vulnerability has been found
+	vulnFound := statusCode == VulnerabilityFoundStatusCode
+	// err will be non-nil if there is a non-zero status code
+	// so if the status code is the special "vulnerability found" status code,
+	// we don't want to report it as a regular error
+	if !vulnFound && err != nil {
+		// delete empty trivy output file that may have been created
+		_ = os.Remove(output)
+		// swallow error if image is not found error, so that we can continue scanning releases
+		// even if some releases failed and we didn't publish images for those releases
+		// this error used to happen if a release was a pre-release and therefore images
+		// weren't pushed to the container registry.
+		// we have since filtered out non-release images from being scanned so this warning
+		// shouldn't occur, but leaving here in case there was another edge case we missed
+		if IsImageNotFoundErr(string(out)) {
+			log.Warnf("image %s not found for version %s", image, version)
+			return false, false, nil
+		}
+		return false, false, eris.Wrapf(err, "error running trivy scan on image %s, version %s, Logs: \n%s", image, version, string(out))
+	}
+	return true, vulnFound, nil
+}
+
+func executeTrivyScanWithRetries(trivyScanArgs []string, retryCount int,
+	backoffStrategy func(int)) ([]byte, int, error) {
+	if retryCount == 0 {
+		retryCount = 5
+	}
+	if backoffStrategy == nil {
+		backoffStrategy = func(attempt int) {
+			time.Sleep(time.Second)
+		}
+	}
+
+	var (
+		out        []byte
+		statusCode int
+		err        error
+	)
+
+	for attempt := 0; attempt < retryCount; attempt++ {
+		trivyScanCmd := exec.Command("trivy", trivyScanArgs...)
+		out, statusCode, err = executils.CombinedOutputWithStatus(trivyScanCmd)
+
+		// If there is no error, don't retry
+		if err == nil {
+			return out, statusCode, err
+		}
+
+		// If there is no image, don't retry
+		if IsImageNotFoundErr(string(out)) {
+			return out, statusCode, err
+		}
+
+		backoffStrategy(attempt)
+	}
+	return out, statusCode, err
+}
+
+func IsImageNotFoundErr(logs string) bool {
+	return strings.Contains(logs, "No such image: ")
+}

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"sort"
 	"text/template"
+	"time"
 
 	"net/http"
 	"net/http/pprof"
@@ -105,8 +106,10 @@ func StartCancellableStatsServerWithPort(ctx context.Context, startupOpts Startu
 	go func() {
 		<-ctx.Done()
 		if server != nil {
-			if err := server.Shutdown(ctx); err != nil {
-				contextutils.LoggerFrom(ctx).Warnf("Stats server shutdown returned error: %v", err)
+			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer shutdownCancel()
+			if err := server.Shutdown(shutdownCtx); err != nil {
+				contextutils.LoggerFrom(shutdownCtx).Warnf("Stats server shutdown returned error: %v", err)
 			}
 		}
 	}()

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -126,7 +126,7 @@ func EventuallyPortAvailable(port int) {
 		}
 		_ = conn.Close()
 		return eris.New(fmt.Sprintf("connection still open on port %d, expected it to be closed", port))
-	}, time.Second*3, time.Millisecond*100).ShouldNot(HaveOccurred())
+	}, time.Second*5, time.Millisecond*100).ShouldNot(HaveOccurred())
 }
 
 func EventuallyRequestReturnsLoggingResponse(request *http.Request, logLevel zapcore.Level) {
@@ -141,18 +141,18 @@ func buildGetLogLevelRequest(port int) (*http.Request, error) {
 	url := fmt.Sprintf("http://localhost:%d/logging", port)
 	body := bytes.NewReader([]byte(url))
 
-	return http.NewRequest("GET", url, body)
+	return http.NewRequest(http.MethodGet, url, body)
 }
 
 func buildSetLogLevelRequest(port int, level zapcore.Level) (*http.Request, error) {
 	url := fmt.Sprintf("http://localhost:%d/logging", port)
 	body := bytes.NewReader([]byte(fmt.Sprintf("{\"level\": \"%s\"}", level.String())))
 
-	req, err := http.NewRequest("PUT", url, body)
+	req, err := http.NewRequest(http.MethodPut, url, body)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add("Context-Type", "application/json")
+	req.Header.Add("Content-Type", "application/json")
 
 	return req, nil
 }


### PR DESCRIPTION
# Description

- Fix bug in Trivy scanner which caused the scan to only run on the latest patch version
- Expose new flag that allows Github issues to be created only for the latest patch version, as opposed to all versions

# Context

## Fix Trivy scan bug
In https://github.com/solo-io/go-utils/issues/478, we identified that our historical scan implementation would create a Github issue for every version scanned that contained a vulnerability, and that this was extremely noisy to developers.

As a result, we added a slight adjustment to the code in https://github.com/solo-io/go-utils/pull/479. The unintended side effect of this was in addition to only creating github issues only for the latest patch release, we also only scanned the latest patch release. This speeds up our weekly job tremendously, but it also no longer produces results for older versions that users might be on. Since vulnerabilities might be identified after that fact, we want to make sure we're scanning all versions, since there might be a new vulnerability identified that we want to make users aware of.

## Expose new flag to only create issues for latest patch releases
We expose a new flag `CreateGithubIssueForLatestPatchVersion`, which when enabled will ensure that when a vulnerability is found for a given version, a github issue will be created only if that version is the latest patch release for that minor version.

## Move code into distinct files
Though these changes are somewhat noisy, and perhaps distract from the PR, I think they are valuable. Reading through the code, I found it challenging at times to distinguish the different components in our scanner. I copied tightly coupled code (trivy, github, predicates) into their own files so that the main scan file can have only the main scanning code.

## Stats logging follow-up
In https://github.com/solo-io/go-utils/pull/487 we added improvement to our stats utility, so that our logging endpoint handler does not throw a NPE. However, the goroutine responsible for waiting for a context to be cancelled and then initiating a server shutdown, was using the same context to shutdown the server, that it was using to determine if the server should be shutdown. This resulted in inconsistent behavior, and the server not being shutdown properly, which would lead to flakes.

This PR added a new context to be used for shutdown.

# Testing
Testing the security scanner end-to-end is challenging. A lot of the code relies on a `github.Client` that cannot be mocked. Therefore for this change I propose the following
1. I added unit tests to cover the case I am trying to solve, that we only create issues for the latest patch release
2. After merging this, I will upgrade the dependency in Gloo, and run the job and manually verify the results. 

## Manual Testing
I use https://github.com/solo-io/gloo/pull/6709 to manually verify these changes. In that PR, I outline the steps required to run the job locally and ways to verify both that (A) we scan all releases and (B) only generate github issues for the latest patch.

BOT NOTES: 
resolves https://github.com/solo-io/go-utils/issues/478