### PR TITLE
Fix NPE in Stats Server Logging Handler

### DIFF
--- a/changelog/v0.21.27/fix-stats-logging-npe.yaml
+++ b/changelog/v0.21.27/fix-stats-logging-npe.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/6449
+    resolvesIssue: false
+    description: Ensure that the handler for the /logging endpoint of the stats server is never nil.

--- a/contextutils/context_and_logging.go
+++ b/contextutils/context_and_logging.go
@@ -37,6 +37,8 @@ var (
 	level zap.AtomicLevel
 )
 
+const LogLevelEnvName = "LOG_LEVEL"
+
 func buildProductionLogger() (*zap.Logger, error) {
 	config := zap.NewProductionConfig()
 	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder

--- a/contextutils/context_and_logging.go
+++ b/contextutils/context_and_logging.go
@@ -128,6 +128,7 @@ func fromContext(ctx context.Context) *zap.SugaredLogger {
 
 func SetLogLevelFromString(logLevel string) {
 	var setLevel zapcore.Level
+
 	switch logLevel {
 	case "debug":
 		setLevel = zapcore.DebugLevel

--- a/contextutils/context_and_logging.go
+++ b/contextutils/context_and_logging.go
@@ -124,8 +124,32 @@ func fromContext(ctx context.Context) *zap.SugaredLogger {
 	return fallbackLogger
 }
 
+func SetLogLevelFromEnv(envLogLevel string) {
+	var setLevel zapcore.Level
+	switch envLogLevel {
+	case "debug":
+		setLevel = zapcore.DebugLevel
+	case "warn":
+		setLevel = zapcore.WarnLevel
+	case "error":
+		setLevel = zapcore.ErrorLevel
+	case "panic":
+		setLevel = zapcore.PanicLevel
+	case "fatal":
+		setLevel = zapcore.FatalLevel
+	default:
+		setLevel = zapcore.InfoLevel
+	}
+
+	SetLogLevel(setLevel)
+}
+
 func SetLogLevel(l zapcore.Level) {
 	level.SetLevel(l)
+}
+
+func GetLogHandler() zap.AtomicLevel {
+	return level
 }
 
 func GetLogLevel() zapcore.Level {

--- a/contextutils/context_and_logging.go
+++ b/contextutils/context_and_logging.go
@@ -126,9 +126,9 @@ func fromContext(ctx context.Context) *zap.SugaredLogger {
 	return fallbackLogger
 }
 
-func SetLogLevelFromEnv(envLogLevel string) {
+func SetLogLevelFromString(logLevel string) {
 	var setLevel zapcore.Level
-	switch envLogLevel {
+	switch logLevel {
 	case "debug":
 		setLevel = zapcore.DebugLevel
 	case "warn":

--- a/stats/runtime.go
+++ b/stats/runtime.go
@@ -25,14 +25,24 @@ func init() {
 }
 
 func RunGoroutineStat() {
+	RunCancellableGoroutineStat(context.Background())
+}
+
+func RunCancellableGoroutineStat(ctx context.Context) {
 	numgoroutines := int64(0)
 	for {
-		time.Sleep(time.Second)
-		newnumgoroutines := int64(runtime.NumGoroutine())
-		diff := newnumgoroutines - numgoroutines
-		numgoroutines = newnumgoroutines
-		if diff != 0 {
-			stats.Record(context.TODO(), MNumGoRoutines.M(diff))
+		select {
+		default:
+			time.Sleep(time.Second)
+			newnumgoroutines := int64(runtime.NumGoroutine())
+			diff := newnumgoroutines - numgoroutines
+			numgoroutines = newnumgoroutines
+			if diff != 0 {
+				stats.Record(context.TODO(), MNumGoRoutines.M(diff))
+			}
+		case <-ctx.Done():
+			return
 		}
+
 	}
 }

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -103,10 +103,9 @@ func StartCancellableStatsServerWithPort(ctx context.Context, startupOpts Startu
 	// Run a separate goroutine to handle the server shutdown when the context is cancelled
 	go func() {
 		<-ctx.Done()
-			if server != nil {
-				if err := server.Shutdown(ctx); err != nil {
-					contextutils.LoggerFrom(ctx).Warnf("Stats server shutdown returned error: %v", err)
-				}
+		if server != nil {
+			if err := server.Shutdown(ctx); err != nil {
+				contextutils.LoggerFrom(ctx).Warnf("Stats server shutdown returned error: %v", err)
 			}
 		}
 	}()

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -96,9 +96,9 @@ func StartCancellableStatsServerWithPort(ctx context.Context, startupOpts Startu
 
 	go func(cancelContext context.Context) {
 		select {
-		case <-ctx.Done():
+		case <-cancelContext.Done():
 			if server != nil {
-				_ = server.Shutdown(ctx)
+				_ = server.Shutdown(cancelContext)
 			}
 		}
 	}(ctx)

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -92,6 +92,7 @@ func StartCancellableStatsServerWithPort(ctx context.Context, startupOpts Startu
 			Addr:    fmt.Sprintf(":%d", startupOpts.Port),
 			Handler: mux,
 		}
+		contextutils.LoggerFrom(ctx).Infof("Stats server starting at %s", server.Addr)
 		err := server.ListenAndServe()
 		if err == http.ErrServerClosed {
 			contextutils.LoggerFrom(ctx).Infof("Stats server closed")

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -68,27 +68,29 @@ func StartCancellableStatsServerWithPort(ctx context.Context, startupOpts Startu
 		contextutils.SetLogLevelFromEnv(envLogLevel)
 	}
 
-	mux := new(http.ServeMux)
-
-	mux.Handle("/logging", getLoggingHandler(startupOpts))
-
-	addhandlers = append(addhandlers, addPprof, addStats)
-
-	for _, addhandler := range addhandlers {
-		addhandler(mux, profileDescriptions)
-	}
-
-	// add the index
-	mux.HandleFunc("/", Index)
-
-	server := &http.Server{
-		Addr:    fmt.Sprintf(":%d", startupOpts.Port),
-		Handler: mux,
-	}
+	// The running instance of the Stats server
+	var server *http.Server
 
 	go RunGoroutineStat()
 
 	go func() {
+		mux := new(http.ServeMux)
+
+		mux.Handle("/logging", getLoggingHandler(startupOpts))
+
+		addhandlers = append(addhandlers, addPprof, addStats)
+
+		for _, addhandler := range addhandlers {
+			addhandler(mux, profileDescriptions)
+		}
+
+		// add the index
+		mux.HandleFunc("/", Index)
+
+		server = &http.Server{
+			Addr:    fmt.Sprintf(":%d", startupOpts.Port),
+			Handler: mux,
+		}
 		_ = server.ListenAndServe()
 	}()
 

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -102,8 +102,7 @@ func StartCancellableStatsServerWithPort(ctx context.Context, startupOpts Startu
 
 	// Run a separate goroutine to handle the server shutdown when the context is cancelled
 	go func() {
-		select {
-		case <-ctx.Done():
+		<-ctx.Done()
 			if server != nil {
 				if err := server.Shutdown(ctx); err != nil {
 					contextutils.LoggerFrom(ctx).Warnf("Stats server shutdown returned error: %v", err)

--- a/stats/stats_suite_test.go
+++ b/stats/stats_suite_test.go
@@ -27,6 +27,6 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	err := os.Setenv(stats.DefaultEnvVar, "")
+	err := os.Unsetenv(stats.DefaultEnvVar)
 	Expect(err).NotTo(HaveOccurred())
 })

--- a/stats/stats_suite_test.go
+++ b/stats/stats_suite_test.go
@@ -1,6 +1,7 @@
 package stats_test
 
 import (
+	"net/http"
 	"os"
 	"testing"
 
@@ -24,6 +25,8 @@ func TestStats(t *testing.T) {
 var _ = BeforeSuite(func() {
 	err := os.Setenv(stats.DefaultEnvVar, stats.DefaultEnabledValue)
 	Expect(err).NotTo(HaveOccurred())
+
+	http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost = 100
 })
 
 var _ = AfterSuite(func() {

--- a/stats/stats_suite_test.go
+++ b/stats/stats_suite_test.go
@@ -1,7 +1,6 @@
 package stats_test
 
 import (
-	"net/http"
 	"os"
 	"testing"
 
@@ -23,10 +22,9 @@ func TestStats(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	// The stats server only starts if appropriate environment variable is set
 	err := os.Setenv(stats.DefaultEnvVar, stats.DefaultEnabledValue)
 	Expect(err).NotTo(HaveOccurred())
-
-	http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost = 100
 })
 
 var _ = AfterSuite(func() {

--- a/stats/stats_suite_test.go
+++ b/stats/stats_suite_test.go
@@ -3,6 +3,9 @@ package stats_test
 import (
 	"testing"
 
+	"github.com/solo-io/go-utils/contextutils"
+	"go.uber.org/zap/zapcore"
+
 	"github.com/onsi/ginkgo/reporters"
 
 	"github.com/solo-io/go-utils/log"
@@ -17,3 +20,8 @@ func TestStats(t *testing.T) {
 	junitReporter := reporters.NewJUnitReporter("junit.xml")
 	RunSpecsWithDefaultAndCustomReporters(t, "Stats Suite", []Reporter{junitReporter})
 }
+
+var _ = BeforeSuite(func() {
+	// Tests in this suite expect the log level to be INFO to start
+	contextutils.SetLogLevel(zapcore.InfoLevel)
+})

--- a/stats/stats_suite_test.go
+++ b/stats/stats_suite_test.go
@@ -1,0 +1,19 @@
+package stats_test
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo/reporters"
+
+	"github.com/solo-io/go-utils/log"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestStats(t *testing.T) {
+	RegisterFailHandler(Fail)
+	log.DefaultOut = GinkgoWriter
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Stats Suite", []Reporter{junitReporter})
+}

--- a/stats/stats_suite_test.go
+++ b/stats/stats_suite_test.go
@@ -1,10 +1,10 @@
 package stats_test
 
 import (
+	"os"
 	"testing"
 
-	"github.com/solo-io/go-utils/contextutils"
-	"go.uber.org/zap/zapcore"
+	"github.com/solo-io/go-utils/stats"
 
 	"github.com/onsi/ginkgo/reporters"
 
@@ -22,6 +22,11 @@ func TestStats(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	// Tests in this suite expect the log level to be INFO to start
-	contextutils.SetLogLevel(zapcore.InfoLevel)
+	err := os.Setenv(stats.DefaultEnvVar, stats.DefaultEnabledValue)
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	err := os.Setenv(stats.DefaultEnvVar, "")
+	Expect(err).NotTo(HaveOccurred())
 })

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -26,6 +26,8 @@ var _ = Describe("Stats", func() {
 		var (
 			ctx    context.Context
 			cancel context.CancelFunc
+
+			startupOptions stats.StartupOptions
 		)
 
 		BeforeEach(func() {
@@ -36,6 +38,9 @@ var _ = Describe("Stats", func() {
 
 			err := os.Unsetenv(contextutils.LogLevelEnvName)
 			Expect(err).NotTo(HaveOccurred())
+
+			// Initialize startupOptions to default value
+			startupOptions = stats.DefaultStartupOptions()
 		})
 
 		AfterEach(func() {
@@ -43,14 +48,10 @@ var _ = Describe("Stats", func() {
 
 			// Ensure that after we cancel the context, which initiates a shutdown of the server,
 			// that we wait for the port to be released, so we can start up a next server on the subsequent test
-			EventuallyPortAvailable(stats.DefaultPort)
+			EventuallyPortAvailable(startupOptions.Port)
 		})
 
 		When("StartOptions are default", func() {
-
-			var (
-				startupOptions stats.StartupOptions
-			)
 
 			BeforeEach(func() {
 				startupOptions = stats.DefaultStartupOptions()
@@ -87,10 +88,6 @@ var _ = Describe("Stats", func() {
 
 		When("StartOptions are default and LOG_LEVEL set", func() {
 
-			var (
-				startupOptions stats.StartupOptions
-			)
-
 			BeforeEach(func() {
 				startupOptions = stats.DefaultStartupOptions()
 
@@ -112,10 +109,6 @@ var _ = Describe("Stats", func() {
 		})
 
 		When("StartOptions.LogLevel is set", func() {
-
-			var (
-				startupOptions stats.StartupOptions
-			)
 
 			BeforeEach(func() {
 				startupOptions = stats.DefaultStartupOptions()

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Stats", func() {
 			// Tests in this suite expect the log level to be INFO to start
 			contextutils.SetLogLevel(zapcore.InfoLevel)
 
-			err := os.Setenv(contextutils.LogLevelEnvName, "")
+			err := os.Unsetenv(contextutils.LogLevelEnvName)
 			Expect(err).NotTo(HaveOccurred())
 		})
 

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -26,7 +26,7 @@ func NextStatsBindPort() int {
 }
 
 func AdvanceBindPort(p *int32) int32 {
-	return atomic.AddInt32(p, 1) + int32(config.GinkgoConfig.ParallelNode*1000)
+	return atomic.AddInt32(p, 1) + int32(config.GinkgoConfig.ParallelNode)
 }
 
 var _ = Describe("Stats", func() {

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -1,0 +1,134 @@
+package stats_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/solo-io/go-utils/contextutils"
+	"github.com/solo-io/go-utils/stats"
+	"github.com/solo-io/go-utils/testutils/goimpl"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+var _ = Describe("Stats", func() {
+
+	Context("StartStatsSeverWithPort", func() {
+
+		var (
+			ctx    context.Context
+			cancel context.CancelFunc
+
+			resetEnvVars func()
+		)
+
+		BeforeEach(func() {
+			ctx, cancel = context.WithCancel(context.Background())
+		})
+
+		AfterEach(func() {
+			cancel()
+
+			resetEnvVars()
+		})
+
+		When("StartOptions are default", func() {
+
+			var (
+				startupOptions stats.StartupOptions
+			)
+
+			BeforeEach(func() {
+				startupOptions = stats.DefaultStartupOptions()
+
+				originalEnvValue := os.Getenv(startupOptions.EnvVar)
+				err := os.Setenv(startupOptions.EnvVar, startupOptions.EnabledValue)
+				Expect(err).NotTo(HaveOccurred())
+
+				resetEnvVars = func() {
+					err := os.Setenv(startupOptions.EnvVar, originalEnvValue)
+					Expect(err).NotTo(HaveOccurred())
+				}
+
+				stats.StartCancellableStatsServerWithPort(ctx, startupOptions)
+			})
+
+			It("can handle requests to /logging", func() {
+				response, err := goimpl.Curl(fmt.Sprintf("http://localhost:%d/logging", startupOptions.Port))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(response).To(Equal("{\"level\":\"info\"}\n"))
+			})
+		})
+
+		When("StartOptions are default and LOG_LEVEL set", func() {
+
+			var (
+				startupOptions stats.StartupOptions
+			)
+
+			BeforeEach(func() {
+				startupOptions = stats.DefaultStartupOptions()
+
+				originalEnvValue := os.Getenv(startupOptions.EnvVar)
+				err := os.Setenv(startupOptions.EnvVar, startupOptions.EnabledValue)
+				Expect(err).NotTo(HaveOccurred())
+
+				originalLogLevel := os.Getenv(contextutils.LogLevelEnvName)
+				err = os.Setenv(contextutils.LogLevelEnvName, "error")
+				Expect(err).NotTo(HaveOccurred())
+
+				resetEnvVars = func() {
+					err = os.Setenv(startupOptions.EnvVar, originalEnvValue)
+					Expect(err).NotTo(HaveOccurred())
+
+					err = os.Setenv(contextutils.LogLevelEnvName, originalLogLevel)
+					Expect(err).NotTo(HaveOccurred())
+				}
+
+				stats.StartCancellableStatsServerWithPort(ctx, startupOptions)
+			})
+
+			It("can handle requests to /logging", func() {
+				response, err := goimpl.Curl(fmt.Sprintf("http://localhost:%d/logging", startupOptions.Port))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(response).To(Equal("{\"level\":\"error\"}\n"))
+			})
+		})
+
+		When("StartOptions.LogLevel is set", func() {
+
+			var (
+				startupOptions stats.StartupOptions
+			)
+
+			BeforeEach(func() {
+				startupOptions = stats.DefaultStartupOptions()
+				customLogLevel := zap.NewAtomicLevelAt(zapcore.DebugLevel)
+				startupOptions.LogLevel = &customLogLevel
+
+				originalEnvValue := os.Getenv(startupOptions.EnvVar)
+				err := os.Setenv(startupOptions.EnvVar, startupOptions.EnabledValue)
+				Expect(err).NotTo(HaveOccurred())
+
+				resetEnvVars = func() {
+					err := os.Setenv(startupOptions.EnvVar, originalEnvValue)
+					Expect(err).NotTo(HaveOccurred())
+				}
+
+				stats.StartCancellableStatsServerWithPort(ctx, startupOptions)
+			})
+
+			It("can handle requests to /logging", func() {
+				response, err := goimpl.Curl(fmt.Sprintf("http://localhost:%d/logging", startupOptions.Port))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(response).To(Equal("{\"level\":\"debug\"}\n"))
+			})
+
+		})
+
+	})
+
+})

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -19,7 +19,7 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-var _ = Describe("Stats", func() {
+var _ = FDescribe("Stats", func() {
 
 	Context("StartStatsSeverWithPort", func() {
 

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -38,9 +38,6 @@ var _ = Describe("Stats", func() {
 
 			err := os.Unsetenv(contextutils.LogLevelEnvName)
 			Expect(err).NotTo(HaveOccurred())
-
-			// Initialize startupOptions to default value
-			startupOptions = stats.DefaultStartupOptions()
 		})
 
 		AfterEach(func() {
@@ -51,7 +48,7 @@ var _ = Describe("Stats", func() {
 			EventuallyPortAvailable(startupOptions.Port)
 		})
 
-		When("StartOptions are default", func() {
+		When("StartupOptions are default", func() {
 
 			BeforeEach(func() {
 				startupOptions = stats.DefaultStartupOptions()
@@ -77,7 +74,7 @@ var _ = Describe("Stats", func() {
 			})
 		})
 
-		When("StartOptions are default and LOG_LEVEL set", func() {
+		When("StartupOptions are default and LOG_LEVEL set", func() {
 
 			BeforeEach(func() {
 				startupOptions = stats.DefaultStartupOptions()
@@ -96,7 +93,7 @@ var _ = Describe("Stats", func() {
 			})
 		})
 
-		When("StartOptions.LogLevel is set", func() {
+		When("StartupOptions.LogLevel is set", func() {
 
 			BeforeEach(func() {
 				startupOptions = stats.DefaultStartupOptions()
@@ -137,7 +134,7 @@ func EventuallyRequestReturnsLoggingResponse(request *http.Request, logLevel zap
 
 	EventuallyWithOffset(1, func() (string, error) {
 		return goimpl.ExecuteRequest(request)
-	}, time.Second*5, time.Second).Should(Equal(expectedResponse))
+	}, time.Second*5, time.Millisecond*100).Should(Equal(expectedResponse))
 }
 
 func buildGetLogLevelRequest(port int) (*http.Request, error) {

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -19,7 +19,7 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-var _ = FDescribe("Stats", func() {
+var _ = Describe("Stats", func() {
 
 	Context("StartStatsSeverWithPort", func() {
 

--- a/testutils/goimpl/curl.go
+++ b/testutils/goimpl/curl.go
@@ -15,7 +15,13 @@ func Curl(url string) (string, error) {
 		return "", err
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	return ExecuteRequest(req)
+}
+
+// ExecuteRequest provides some of the functionality you would expect from the curl command.
+// This saves you from having to call the curl binary in environments where that binary is not available.
+func ExecuteRequest(request *http.Request) (string, error) {
+	resp, err := http.DefaultClient.Do(request)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
# Description

Ensure that the stats server can handle requests to the `/logging` endpoint

# Context

## Gloo Edge Context
The logging endpoint is a useful feature for debugging components. In fact, we even recommend this feature in our production debugging docs for Gloo Edge: https://docs.solo.io/gloo-edge/latest/operations/debugging_gloo/#changing-logging-levels-and-more

## Problem
This feature has been broken for a while. You can see the [history](https://github.com/solo-io/go-utils/commits/master/stats/stats.go), but it has changed enough and been broken in different ways, that I decided to add a robust set of tests around the functionality.

In its most recent state, this handler is nil every time, unless the StartupOptions define a custom LogLevel.

## Solution
I introduced a context aspect to this server, to ensure that we can shutdown the server when the parent context is cancelled. Without this functionality, consecutive tests would fail, because the listener would never be shutdown and we would return stale config.

# How is this tested
- I added a variety of unit tests to ensure that we can use the logging endpoint to return the current log level, given a variety of startup options.
- I added a test to ensure that we can use the logging endpoint to change the log level, without requiring a restart to the server

I encountered some flakes, so to confirm that these tests don't introduce any flakes, I ran:
```
ginkgo -r -failFast -trace -progress -compilers=4 -failOnPending -noColor -randomizeSuites   -randomizeAllSpecs -untilItFails stats
```
and let it run for a while, before quitting