### PR TITLE
feat(changelogutils): added `activeSubdirectory` field to "validation.yaml"

### DIFF
--- a/changelog/v0.22.3/configurable-changelog-dir.yaml
+++ b/changelog/v0.22.3/configurable-changelog-dir.yaml
@@ -1,0 +1,3 @@
+changelog:
+- type: NON_USER_FACING
+  description: added ability to validate changelogs in a subdirectory by specifying `activeSubdirectory` in "validation.yaml".  This should enable users to have less sprawling changelog directorys as time progresses.

--- a/changelogutils/changelog.go
+++ b/changelogutils/changelog.go
@@ -62,6 +62,8 @@ type Changelog struct {
 }
 
 const (
+	// all functions in this file that use ChangelogDirectory are marked deprecated.  The hope
+	// is we don't need to account for the "ActiveSubdirectory" setting which was added _after_ said deprecation
 	ChangelogDirectory = "changelog"
 	SummaryFile        = "summary.md"
 	ClosingFile        = "closing.md"

--- a/changelogutils/reader.go
+++ b/changelogutils/reader.go
@@ -53,13 +53,11 @@ func NewChangelogReader(code vfsutils.MountedRepo) ChangelogReader {
 }
 
 func (c *changelogReader) GetChangelogDirectory(ctx context.Context) (string, error) {
-	// ripped from validator.go.GetValidationSettings(...).  Working assumption is that
-	// client.FileExists is redundant, as code.GetFileContents should _also_ fail when
-	// no client is present
 	var settings ValidationSettings
 	bytes, err := c.code.GetFileContents(ctx, GetValidationSettingsPath())
 	if err != nil {
-		return "", UnableToGetSettingsError(err)
+		// unable to read validtion.yaml ~= "validation.yaml is not there"
+		return "changelog", nil
 	}
 
 	if err := yaml.Unmarshal(bytes, &settings); err != nil {

--- a/changelogutils/reader.go
+++ b/changelogutils/reader.go
@@ -52,6 +52,26 @@ func NewChangelogReader(code vfsutils.MountedRepo) ChangelogReader {
 	return &changelogReader{code: code}
 }
 
+func (c *changelogReader) GetChangelogDirectory(ctx context.Context) (string, error) {
+	// ripped from validator.go.GetValidationSettings(...).  Working assumption is that
+	// client.FileExists is redundant, as code.GetFileContents should _also_ fail when
+	// no client is present
+	var settings ValidationSettings
+	bytes, err := c.code.GetFileContents(ctx, GetValidationSettingsPath())
+	if err != nil {
+		return "", UnableToGetSettingsError(err)
+	}
+
+	if err := yaml.Unmarshal(bytes, &settings); err != nil {
+		return "", UnableToGetSettingsError(err)
+	}
+
+	if settings.ActiveSubdirectory != "" {
+		return "changelog/" + settings.ActiveSubdirectory, err
+	}
+	return "changelog", err
+}
+
 func (c *changelogReader) GetChangelogForTag(ctx context.Context, tag string) (*Changelog, error) {
 	version, err := versionutils.ParseVersion(tag)
 	if err != nil {
@@ -60,7 +80,12 @@ func (c *changelogReader) GetChangelogForTag(ctx context.Context, tag string) (*
 	changelog := Changelog{
 		Version: version,
 	}
-	changelogPath := filepath.Join(ChangelogDirectory, tag)
+	dir, err := c.GetChangelogDirectory(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	changelogPath := filepath.Join(dir, tag)
 	files, err := c.code.ListFiles(ctx, changelogPath)
 	if err != nil {
 		return nil, UnableToListFilesError(err, changelogPath)

--- a/changelogutils/reader_test.go
+++ b/changelogutils/reader_test.go
@@ -94,6 +94,9 @@ var _ = Describe("ReaderTest", func() {
 			mockCode.EXPECT().
 				ListFiles(ctx, changelogDir).
 				Return(nil, nestedErr)
+			mockCode.EXPECT().
+				GetFileContents(ctx, "changelog/validation.yaml").
+				Return([]byte(""), nil)
 
 			expected := changelogutils.UnableToListFilesError(nestedErr, changelogDir)
 			changelog, err := reader.GetChangelogForTag(ctx, tag)
@@ -106,6 +109,9 @@ var _ = Describe("ReaderTest", func() {
 			mockCode.EXPECT().
 				ListFiles(ctx, changelogDir).
 				Return(files, nil)
+			mockCode.EXPECT().
+				GetFileContents(ctx, "changelog/validation.yaml").
+				Return([]byte(""), nil)
 
 			expected := changelogutils.UnexpectedDirectoryError("foo", changelogDir)
 
@@ -123,6 +129,9 @@ var _ = Describe("ReaderTest", func() {
 			mockCode.EXPECT().
 				GetFileContents(ctx, path).
 				Return([]byte(contents), err)
+			mockCode.EXPECT().
+				GetFileContents(ctx, "changelog/validation.yaml").
+				Return([]byte(""), nil)
 			return path
 		}
 
@@ -220,6 +229,9 @@ var _ = Describe("ReaderTest", func() {
 			mockCode.EXPECT().
 				ListFiles(ctx, changelogDir).
 				Return(files, nil)
+			mockCode.EXPECT().
+				GetFileContents(ctx, "changelog/validation.yaml").
+				Return([]byte(""), nil)
 			mockCode.EXPECT().
 				GetFileContents(ctx, filepath.Join(changelogDir, "1.yaml")).
 				Return([]byte(validChangelog1), nil)
@@ -322,6 +334,9 @@ var _ = Describe("ReaderTest", func() {
 				ListFiles(ctx, rcDir).
 				Return(files, nil)
 			mockCode.EXPECT().
+				GetFileContents(ctx, "changelog/validation.yaml").
+				Return([]byte(""), nil)
+			mockCode.EXPECT().
 				GetFileContents(ctx, filepath.Join(rcDir, "1.yaml")).
 				Return([]byte(validChangelog3), nil)
 
@@ -353,6 +368,9 @@ var _ = Describe("ReaderTest", func() {
 			mockCode.EXPECT().
 				ListFiles(ctx, changelogDir).
 				Return(files, nil)
+			mockCode.EXPECT().
+				GetFileContents(ctx, "changelog/validation.yaml").
+				Return([]byte(""), nil)
 			mockCode.EXPECT().
 				GetFileContents(ctx, filepath.Join(changelogDir, "1.yaml")).
 				Return([]byte(validStableReleaseChangelog), nil)


### PR DESCRIPTION
This should enable users to have less sprawling changelog directorys as time progresses.  Consider a directory like...
```yaml
changelog:
  v1.0.0
  v1.0.1
  v1.0.2
  v1.1.0
  v1.1.1
  v1.1.2
  v1.1.3
```

By specifying a activeSubdirectory="v1.1", you could achieve a more readable structure of
```yaml
changelog:
  v1.0:
    v1.0.0
    v1.0.1
    v1.0.2
  v1.1
    v1.1.0
    v1.1.1
    v1.1.2
    v1.1.3
```