### PR TITLE
versionutils: support more than 1 label variant and their strict order

### DIFF
--- a/changelog/v0.23.1/changelog-specialnames.yaml
+++ b/changelog/v0.23.1/changelog-specialnames.yaml
@@ -1,5 +1,6 @@
 changelog:
   - type: FIX
+    issueLink: https://github.com/solo-io/go-utils/issues/0000
     description: >
       Allow for an overridable set of specially ordered changelog endings.
       Historically we have only used one ending so this is not considered technically breaking.

--- a/changelog/v0.23.1/changelog-specialnames.yaml
+++ b/changelog/v0.23.1/changelog-specialnames.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    description: >
+      Allow for an overridable set of specially ordered changelog endings.
+      Historically we have only used one ending so this is not considered technically breaking.

--- a/changelogutils/changelog_test.go
+++ b/changelogutils/changelog_test.go
@@ -18,13 +18,13 @@ import (
 	"github.com/spf13/afero"
 )
 
-var _ = Describe("ChangelogTest", func() {
+var _ = FDescribe("ChangelogTest", func() {
 
 	var _ = Context("GetProposedTag", func() {
 		getProposedTag := func(latestTag, changelogDir, tag string) error {
 			fs := afero.NewOsFs()
 			actualTag, actualErr := changelogutils.GetProposedTag(fs, latestTag, changelogDir)
-			Expect(actualTag).To(BeEquivalentTo(tag))
+			Expect(actualTag).To(BeEquivalentTo(tag), actualErr)
 			return actualErr
 		}
 

--- a/changelogutils/changelog_test.go
+++ b/changelogutils/changelog_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-var _ = FDescribe("ChangelogTest", func() {
+var _ = Describe("ChangelogTest", func() {
 
 	var _ = Context("GetProposedTag", func() {
 		getProposedTag := func(latestTag, changelogDir, tag string) error {

--- a/changelogutils/changelog_test.go
+++ b/changelogutils/changelog_test.go
@@ -24,7 +24,7 @@ var _ = FDescribe("ChangelogTest", func() {
 		getProposedTag := func(latestTag, changelogDir, tag string) error {
 			fs := afero.NewOsFs()
 			actualTag, actualErr := changelogutils.GetProposedTag(fs, latestTag, changelogDir)
-			Expect(actualTag).To(BeEquivalentTo(tag), actualErr)
+			Expect(actualTag).To(BeEquivalentTo(tag), fmt.Sprintf("%v", actualErr))
 			return actualErr
 		}
 

--- a/versionutils/version.go
+++ b/versionutils/version.go
@@ -133,10 +133,10 @@ func (v Version) IsGreaterThan(lesser Version) (bool, bool) {
 	if v.Label == lesser.Label {
 		if v.LabelVersion > lesser.LabelVersion {
 			return true, true
-		} else if v.LabelVersion < lesser.LabelVersion {
-			return false, true
 		}
-		return false, false
+		// is determinabley not greater than
+		return false, true
+
 	}
 
 	// impose additional ordering based on our special labels

--- a/versionutils/version.go
+++ b/versionutils/version.go
@@ -136,6 +136,7 @@ func (v Version) IsGreaterThan(lesser Version) (bool, bool) {
 		} else if v.LabelVersion < lesser.LabelVersion {
 			return false, true
 		}
+		return false, false
 	}
 
 	// impose additional ordering based on our special labels

--- a/versionutils/version.go
+++ b/versionutils/version.go
@@ -141,10 +141,12 @@ func (v Version) IsGreaterThan(lesser Version) (bool, bool) {
 
 	// impose additional ordering based on our special labels
 	for _, label := range SpeciallyOrderedPrefixes {
-		if strings.HasPrefix(v.Label, label) {
+
+		if v.Label == label {
+			// we know that they arent the same so we can return immediately
 			return true, true
 		}
-		if strings.HasPrefix(lesser.Label, label) {
+		if lesser.Label == label {
 			return false, true
 		}
 	}

--- a/versionutils/version.go
+++ b/versionutils/version.go
@@ -21,6 +21,7 @@ const (
 // SpeciallyOrderedPrefixes are prefixes that are ordered in a special way
 // This is exported so that consuming packages can specify their own special labels
 // These formats take precedence over alphanumeric ordering for labels
+// Labels take are ordered in increasing order of precedence
 var SpeciallyOrderedPrefixes = []string{"rc", "beta", "dev"}
 
 var (


### PR DESCRIPTION
The default list can be overridden by any consumer if they so choose but it states when a format is better than alphanumeric. 
One consideration reviewers should take into account is whether it makes sense to use string prefix or to convert these things into a regex. As it is now rcblah1 will be treated like rc1 which may not be ideal but in general it makes the code cleaner.
BOT NOTES: 
resolves https://github.com/solo-io/go-utils/issues/0000