### PR TITLE
New benchmark function

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -19,17 +19,17 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Setup GCloud Auth
-      uses: google-github-actions/auth@v1
+    - name: Set up Python
+      uses: actions/setup-python@v4
       with:
+        python-version: 3.8
+    - uses: google-github-actions/setup-gcloud@a48b55b3b0eeaf77b6e1384aab737fbefe2085ac
+      with:
+        version: '290.0.1'
         project_id: ${{ secrets.GCP_PROJECT_ID }}
-        credentials_json: ${{ secrets.GCP_SA_KEY }}
-        create_credentials_file: true
-        export_environment_variables: true
-    - name: Setup GCloud SDK
-      uses: google-github-actions/setup-gcloud@v1.1.0
-      with:
-        version: '>= 386.0.0'
+        service_account_key: ${{ secrets.GCP_SA_KEY }}
+        export_default_credentials: true
+      name: Gcloud Login
     - name: Install Trivy
       run: |
         wget https://github.com/aquasecurity/trivy/releases/download/v0.18.3/trivy_0.18.3_Linux-64bit.deb

--- a/changelog/v0.24.1/new-benchmark-util.yaml
+++ b/changelog/v0.24.1/new-benchmark-util.yaml
@@ -1,0 +1,8 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/solo-io/go-utils/issues/511
+  description: >
+    Added the `Measure` function to the `benchmarking` test utility package. 
+    The new function measures the portion of time a given test function spent in user mode, 
+    in kernel mode, and on both of them combined. The other functions in the same package have been deprecated
+    and will be removed when other repositories will stop depending on them.

--- a/testutils/benchmarking/benchmarking.go
+++ b/testutils/benchmarking/benchmarking.go
@@ -90,8 +90,11 @@ func TimeForFuncToComplete(f func()) float64 {
 	realRuntime := realDuration2 - realDuration1
 	fmt.Printf("realUserRuntime: %v\n", realRuntime)
 
-	fmt.Printf("utime: %f\n", userRuntime.Seconds())
-	Expect(userRuntime.Seconds()).Should(
+	fmt.Printf("utime:         %f\n", userRuntime.Seconds())
+	fmt.Printf("utime + stime: %f\n", realRuntime.Seconds())
+	Expect(realRuntime.Seconds()).Should(
 		BeNumerically(">", 0))
+
+	// TODO(marco): let's leave it as is so I don't need to adjust the thresholds for now
 	return userRuntime.Seconds()
 }

--- a/testutils/benchmarking/benchmarking.go
+++ b/testutils/benchmarking/benchmarking.go
@@ -87,7 +87,7 @@ type Result struct {
 }
 
 // Measure returns the time it took to execute the given function. It only compiles on Linux.
-// Most often you will want  to run the code you want to test in a loop to get more sizeable readings, e.g.:
+// Most often you will want to run the code you want to test in a loop to get more sizeable readings, e.g.:
 //
 //	results := benchmarking.Measure(func() {
 //		for i := 0; i < 100; i++ {

--- a/testutils/benchmarking/benchmarking.go
+++ b/testutils/benchmarking/benchmarking.go
@@ -101,6 +101,7 @@ type Result struct {
 // Further ideas for improvement:
 //   - we could explore running tests with nice and/or ionice
 //   - could also further explore running the tests with docker flags --cpu-shares set
+//   - consider setting GOMAXPROCS when running the tests to ensure we run in a single thread
 func Measure(f func()) (Result, error) {
 
 	before, after, err := doMeasure(f)

--- a/testutils/benchmarking/benchmarking.go
+++ b/testutils/benchmarking/benchmarking.go
@@ -91,7 +91,7 @@ type Result struct {
 //
 //	results := benchmarking.Measure(func() {
 //		for i := 0; i < 100; i++ {
-//			myFastTestFunc()
+//			funcToTest()
 //		}
 //	})
 //

--- a/testutils/benchmarking/benchmarking.go
+++ b/testutils/benchmarking/benchmarking.go
@@ -2,6 +2,7 @@ package benchmarking
 
 import (
 	"fmt"
+	errors "github.com/rotisserie/eris"
 	"runtime"
 	"runtime/debug"
 	"syscall"
@@ -20,30 +21,6 @@ import (
 //     has helped improve reliability of benchmarks
 //   - we could still explore running tests with nice and/or ionice
 //   - could also further explore running the tests with docker flags --cpu-shares set
-func ExpectFuncToComplete(f func(), runtimeThresholdInSeconds float64) {
-	var rusage1 syscall.Rusage
-	var rusage2 syscall.Rusage
-	runtime.LockOSThread()                                    // important to lock OS thread to ensure we are the only goroutine being benchmarked
-	prevGc := debug.SetGCPercent(-1)                          // might just be paranoid, but disable gc while benchmarking
-	err := syscall.Getrusage(syscall.RUSAGE_THREAD, &rusage1) // RUSAGE_THREAD system call only works/compiles on linux
-	if err != nil {
-		Expect(err).ToNot(HaveOccurred())
-	}
-	f()
-	err = syscall.Getrusage(syscall.RUSAGE_THREAD, &rusage2)
-	if err != nil {
-		Expect(err).ToNot(HaveOccurred())
-	}
-	debug.SetGCPercent(prevGc)
-	runtime.UnlockOSThread()
-	duration1 := time.Duration(rusage1.Utime.Nano())
-	duration2 := time.Duration(rusage2.Utime.Nano())
-	userRuntime := duration2 - duration1
-	fmt.Printf("utime: %f\n", userRuntime.Seconds())
-	Expect(userRuntime.Seconds()).Should(And(
-		BeNumerically("<=", runtimeThresholdInSeconds),
-		BeNumerically(">", 0)))
-}
 
 func TimeForFuncToComplete(f func()) float64 {
 	var rusage1 syscall.Rusage
@@ -97,4 +74,74 @@ func TimeForFuncToComplete(f func()) float64 {
 
 	// TODO(marco): let's leave it as is so I don't need to adjust the thresholds for now
 	return userRuntime.Seconds()
+}
+
+// Result represents the result of measuring a function's execution time.
+type Result struct {
+	// Time spent in user mode
+	Utime time.Duration
+	// Time spent in kernel mode
+	Stime time.Duration
+	// Time spent in user mode + kernel mode
+	Total time.Duration
+}
+
+// Measure returns the time it took to execute the given function. It only compiles on Linux.
+// Most often you will want  to run the code you want to test in a loop to get more sizeable readings, e.g.:
+//
+//	results := benchmarking.Measure(func() {
+//		for i := 0; i < 100; i++ {
+//			myFastTestFunc()
+//		}
+//	})
+//
+// Measure should be preferred over the Gomega benchmark utils (https://pkg.go.dev/github.com/onsi/gomega/gmeasure)
+// as it takes some additional steps to ensure we get accurate measurements.
+//
+// Further ideas for improvement:
+//   - we could explore running tests with nice and/or ionice
+//   - could also further explore running the tests with docker flags --cpu-shares set
+func Measure(f func()) (Result, error) {
+
+	before, after, err := doMeasure(f)
+	if err != nil {
+		return Result{}, err
+	}
+
+	res := Result{
+		Utime: time.Duration(after.Utime.Nano() - before.Utime.Nano()),
+		Stime: time.Duration(after.Stime.Nano() - before.Stime.Nano()),
+		Total: time.Duration(after.Utime.Nano() + after.Stime.Nano() - before.Utime.Nano() - before.Stime.Nano()),
+	}
+
+	// Time spent in user + kernel modes can't reasonably be 0ns, so err on the side of caution and fail.
+	if res.Total == 0 {
+		return Result{}, errors.New("total execution time was 0 ns")
+	}
+
+	return res, nil
+}
+
+func doMeasure(f func()) (before syscall.Rusage, after syscall.Rusage, err error) {
+
+	// Important: lock OS thread to ensure we are the only goroutine being benchmarked
+	runtime.LockOSThread()
+
+	// Might just be paranoid, but disable garbage collection while benchmarking
+	prevGc := debug.SetGCPercent(-1)
+
+	defer func() {
+		debug.SetGCPercent(prevGc)
+		runtime.UnlockOSThread()
+	}()
+
+	// getrusage system call only works/compiles on linux
+	if err = syscall.Getrusage(syscall.RUSAGE_THREAD, &before); err != nil {
+		return
+	}
+
+	f()
+
+	err = syscall.Getrusage(syscall.RUSAGE_THREAD, &after)
+	return
 }

--- a/testutils/benchmarking/benchmarking.go
+++ b/testutils/benchmarking/benchmarking.go
@@ -38,41 +38,12 @@ func TimeForFuncToComplete(f func()) float64 {
 	}
 	debug.SetGCPercent(prevGc)
 	runtime.UnlockOSThread()
-
-	fmt.Printf("rusage1: %v\n", rusage1)
-	fmt.Printf("rusage2: %v\n", rusage2)
-
 	duration1 := time.Duration(rusage1.Utime.Nano())
 	duration2 := time.Duration(rusage2.Utime.Nano())
-
-	fmt.Printf("utime1: %v\n", duration1)
-	fmt.Printf("utime2: %v\n", duration2)
-	fmt.Printf("utime1.nano: %v\n", duration1.Nanoseconds())
-	fmt.Printf("utime2.nano: %v\n", duration2.Nanoseconds())
-
-	stime1 := time.Duration(rusage1.Stime.Nano())
-	stime2 := time.Duration(rusage2.Stime.Nano())
-	fmt.Printf("stime1: %v\n", stime1)
-	fmt.Printf("stime2: %v\n", stime2)
-	fmt.Printf("stime1.nano: %v\n", stime1.Nanoseconds())
-	fmt.Printf("stime2.nano: %v\n", stime2.Nanoseconds())
-
 	userRuntime := duration2 - duration1
-	fmt.Printf("userRuntime: %v\n", userRuntime)
-	fmt.Printf("userRuntime.Seconds: %v\n", userRuntime.Seconds())
-	fmt.Printf("userRuntime.Nanos: %v\n", userRuntime.Nanoseconds())
-
-	realDuration1 := duration1 + stime1
-	realDuration2 := duration2 + stime2
-	realRuntime := realDuration2 - realDuration1
-	fmt.Printf("realUserRuntime: %v\n", realRuntime)
-
-	fmt.Printf("utime:         %f\n", userRuntime.Seconds())
-	fmt.Printf("utime + stime: %f\n", realRuntime.Seconds())
-	Expect(realRuntime.Seconds()).Should(
+	fmt.Printf("utime: %f\n", userRuntime.Seconds())
+	Expect(userRuntime.Seconds()).Should(
 		BeNumerically(">", 0))
-
-	// TODO(marco): let's leave it as is so I don't need to adjust the thresholds for now
 	return userRuntime.Seconds()
 }
 

--- a/testutils/benchmarking/benchmarking.go
+++ b/testutils/benchmarking/benchmarking.go
@@ -68,16 +68,27 @@ func TimeForFuncToComplete(f func()) float64 {
 	duration1 := time.Duration(rusage1.Utime.Nano())
 	duration2 := time.Duration(rusage2.Utime.Nano())
 
-	fmt.Printf("duration1: %v\n", duration1)
-	fmt.Printf("duration2: %v\n", duration2)
-	fmt.Printf("duration1.nano: %v\n", duration1.Nanoseconds())
-	fmt.Printf("duration2.nano: %v\n", duration2.Nanoseconds())
+	fmt.Printf("utime1: %v\n", duration1)
+	fmt.Printf("utime2: %v\n", duration2)
+	fmt.Printf("utime1.nano: %v\n", duration1.Nanoseconds())
+	fmt.Printf("utime2.nano: %v\n", duration2.Nanoseconds())
+
+	stime1 := time.Duration(rusage1.Stime.Nano())
+	stime2 := time.Duration(rusage2.Stime.Nano())
+	fmt.Printf("stime1: %v\n", stime1)
+	fmt.Printf("stime2: %v\n", stime2)
+	fmt.Printf("stime1.nano: %v\n", stime1.Nanoseconds())
+	fmt.Printf("stime2.nano: %v\n", stime2.Nanoseconds())
 
 	userRuntime := duration2 - duration1
-
 	fmt.Printf("userRuntime: %v\n", userRuntime)
 	fmt.Printf("userRuntime.Seconds: %v\n", userRuntime.Seconds())
 	fmt.Printf("userRuntime.Nanos: %v\n", userRuntime.Nanoseconds())
+
+	realDuration1 := duration1 + stime1
+	realDuration2 := duration2 + stime2
+	realRuntime := realDuration2 - realDuration1
+	fmt.Printf("realUserRuntime: %v\n", realRuntime)
 
 	fmt.Printf("utime: %f\n", userRuntime.Seconds())
 	Expect(userRuntime.Seconds()).Should(

--- a/testutils/benchmarking/benchmarking.go
+++ b/testutils/benchmarking/benchmarking.go
@@ -61,9 +61,24 @@ func TimeForFuncToComplete(f func()) float64 {
 	}
 	debug.SetGCPercent(prevGc)
 	runtime.UnlockOSThread()
+
+	fmt.Printf("rusage1: %v\n", rusage1)
+	fmt.Printf("rusage2: %v\n", rusage2)
+
 	duration1 := time.Duration(rusage1.Utime.Nano())
 	duration2 := time.Duration(rusage2.Utime.Nano())
+
+	fmt.Printf("duration1: %v\n", duration1)
+	fmt.Printf("duration2: %v\n", duration2)
+	fmt.Printf("duration1.nano: %v\n", duration1.Nanoseconds())
+	fmt.Printf("duration2.nano: %v\n", duration2.Nanoseconds())
+
 	userRuntime := duration2 - duration1
+
+	fmt.Printf("userRuntime: %v\n", userRuntime)
+	fmt.Printf("userRuntime.Seconds: %v\n", userRuntime.Seconds())
+	fmt.Printf("userRuntime.Nanos: %v\n", userRuntime.Nanoseconds())
+
 	fmt.Printf("utime: %f\n", userRuntime.Seconds())
 	Expect(userRuntime.Seconds()).Should(
 		BeNumerically(">", 0))


### PR DESCRIPTION
## Summary
This PR adds the `Measure` function to the `benchmarking` test utility package. The new function measures the portion of time a given test function spent in user mode, in kernel mode, and in both of them combined. The other functions in the same package have been deprecated and will be removed when other repositories will stop depending on them.

## Motivation
The change was prompted by the fact that the current `TimeForFuncToComplete` function is in some instances reporting execution times of 0 nanoseconds, which causes failures in benchmark tests. I had encountered this problem [before](https://github.com/solo-io/ext-auth-service/pull/425#issuecomment-1276678054) and decided to spend some time to investigate it this time around as it seemed to be manifesting itself increasingly often during [my refactoring of CI in the ext-auth-service repository](https://github.com/solo-io/ext-auth-service/pull/540).

The issue is caused by the fact that we only measure time spent in user mode and that in some cases a function spends all of its time in kernel mode. An example can be found in [this test run](https://github.com/solo-io/ext-auth-service/actions/runs/4864169861/jobs/8672838054), where you can see that the `utime` (the first field in that poorly logged struct) is the same before and after the execution of the test function, while the `stime` (second field) goes from 0 to 15875µs: 

```
rusage1: {{0 149100} {0 0} 232368 0 0 0 78 0 0 0 0 0 0 0 15 61}
rusage2: {{0 149100} {0 15875} 232368 0 0 0 97 0 0 0 0 0 0 0 15 62}
```

I was not able to find out why this is happening in the time I gave myself to look into this. It would be interesting to understand this, but I don't think it is worth the effort at this moment.

## Solution
Regardless of the cause of the problem, I think we should take into account both the time we spend in user and kernel modes when benchmarking a function, so I added a new function that returns both of those pieces of information. This way the caller can decide which piece of information they want to use. I still kept a check on zero execution time, but it is run against `utime+stime` instead of just `utime`.

As a side note, the new function does not run assertions or write to standard output, I think that should be left to the caller as well.

BOT NOTES: 
resolves https://github.com/solo-io/go-utils/issues/511