### PR TITLE
Fix testutils double import issue

### DIFF
--- a/changelog/v0.24.2/fix-test-utils-double-import.yaml
+++ b/changelog/v0.24.2/fix-test-utils-double-import.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    description: >
+      Fix issue where testutils was importing two different versions of the `ginkgo` and `errors` packages.
+    issueLink: https://github.com/solo-io/gloo/issues/8164
+    resolvesIssue: false

--- a/testutils/exec/cmd.go
+++ b/testutils/exec/cmd.go
@@ -7,9 +7,6 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/onsi/ginkgo"
-	"github.com/pkg/errors"
-
 	"github.com/onsi/ginkgo/v2"
 	"github.com/pkg/errors"
 )


### PR DESCRIPTION
Removed double-importing of "github.com/pkg/errors" and the import of the non-v2 "github.com/onsi/ginkgo"

# Context
Faced an error in solo-project's [CI](https://console.cloud.google.com/cloud-build/builds/98233170-52e0-4aa2-bdd3-05adb9d4b478?project=gloo-ee) due to the `v0.24.1` update.

```
Step #0 - "tests": Step #12 - "test": # github.com/solo-io/go-utils/testutils/exec
Step #0 - "tests": Step #12 - "test": /go/pkg/mod/github.com/solo-io/go-utils@v0.24.1/testutils/exec/cmd.go:13:2: ginkgo redeclared in this block
Step #0 - "tests": Step #12 - "test": 	/go/pkg/mod/github.com/solo-io/go-utils@v0.24.1/testutils/exec/cmd.go:10:2: other declaration of ginkgo
Step #0 - "tests": Step #12 - "test": /go/pkg/mod/github.com/solo-io/go-utils@v0.24.1/testutils/exec/cmd.go:13:2: "github.com/onsi/ginkgo/v2" imported as ginkgo and not used
Step #0 - "tests": Step #12 - "test": /go/pkg/mod/github.com/solo-io/go-utils@v0.24.1/testutils/exec/cmd.go:14:2: errors redeclared in this block
Step #0 - "tests": Step #12 - "test": 	/go/pkg/mod/github.com/solo-io/go-utils@v0.24.1/testutils/exec/cmd.go:11:2: other declaration of errors
Step #0 - "tests": Step #12 - "test": /go/pkg/mod/github.com/solo-io/go-utils@v0.24.1/testutils/exec/cmd.go:14:2: "github.com/pkg/errors" imported and not used
```