### PR TITLE
[13898] Fix formatting; Explicitly state no vulnerabilities

### DIFF
--- a/changelog/v0.25.1/13898-formatting-missing-images.yaml
+++ b/changelog/v0.25.1/13898-formatting-missing-images.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo-mesh-enterprise/issues/13898
+    description: >
+      Fix missing newline in scanner output Markdown.
+      Explicitly report "No Vulnerabilities Found" in Markdown for images when applicable.

--- a/securityscanutils/securityscan.go
+++ b/securityscanutils/securityscan.go
@@ -267,7 +267,7 @@ func (r *SecurityScanRepo) RunMarkdownScan(ctx context.Context, release *github.
 			if errors.Is(err, UnrecoverableErr) {
 				return eris.Wrapf(err, "error running image scan on image %s", imageWithRepo)
 			}
-			vulnerabilityMd += fmt.Sprintf("# %s\n\n %s", imageWithRepo, err)
+			vulnerabilityMd += fmt.Sprintf("# %s\n\n %s\n", imageWithRepo, err)
 		}
 
 		if vulnFound {
@@ -276,6 +276,8 @@ func (r *SecurityScanRepo) RunMarkdownScan(ctx context.Context, release *github.
 				return eris.Wrapf(err, "error reading trivy markdown scan file %s to generate github issue", output)
 			}
 			vulnerabilityMd += fmt.Sprintf("# %s\n\n %s\n\n", imageWithRepo, trivyScanMd)
+		} else {
+			vulnerabilityMd += fmt.Sprintf("# %s\n\n No Vulnerabilities Found for %s\n\n", imageWithRepo, imageWithRepo)
 		}
 
 	}


### PR DESCRIPTION
BOT NOTES: 
resolves https://github.com/solo-io/gloo-mesh-enterprise/issues/13898

Diff of generated Markdown.
The issue mentions a few images missing from the 2.4.7 report which are now included after these changes.
![Screenshot 2024-01-16 at 12 46 57 PM](https://github.com/solo-io/go-utils/assets/121651828/779e34ed-54d5-4bd8-bfac-e80f265b1ed9)
