### PR TITLE
BuildLoggerFromConfig

### DIFF
--- a/contextutils/context_and_logging.go
+++ b/contextutils/context_and_logging.go
@@ -109,16 +109,19 @@ func init() {
 		buildLogger = buildSplitOutputProductionLogger
 	}
 	if logger, err := buildLogger(); err != nil {
+		fmt.Printf("ERROR BUILDING LOGGER: %v\n", err)
 
 		// We failed to create a fallback logger. Our fallback
 		// unfortunately falls back to noop.
 		fallbackLogger = zap.NewNop().Sugar()
 	} else {
+		fmt.Printf("SETTING FALLBACKLOGGER TO LOGGER FROM BUILDLOGGER()\n")
 		fallbackLogger = logger.Sugar()
 	}
 }
 
 func SetFallbackLogger(logger *zap.SugaredLogger) {
+	fmt.Printf("IN SetFallbackLogger()\n")
 	fallbackLogger = logger
 }
 
@@ -132,11 +135,14 @@ func withLogger(ctx context.Context, logger *zap.SugaredLogger) context.Context 
 // Returns nil if no logger is set in context, or if the stored value is
 // not of correct type.
 func fromContext(ctx context.Context) *zap.SugaredLogger {
+	fmt.Printf("GETTING LOGGER FROM CONTEXT: %+v\n", ctx)
 	if ctx != nil {
 		if logger, ok := ctx.Value(loggerKey{}).(*zap.SugaredLogger); ok {
+			fmt.Printf("USING EXISTING LOGGER IN CONTEXT\n")
 			return logger
 		}
 	}
+	fmt.Printf("RETURNING FALLBACK LOGGER\n")
 	return fallbackLogger
 }
 

--- a/contextutils/context_and_logging.go
+++ b/contextutils/context_and_logging.go
@@ -19,7 +19,6 @@ package contextutils
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"go.uber.org/zap"
@@ -145,14 +144,11 @@ func withLogger(ctx context.Context, logger *zap.SugaredLogger) context.Context 
 // Returns nil if no logger is set in context, or if the stored value is
 // not of correct type.
 func fromContext(ctx context.Context) *zap.SugaredLogger {
-	fmt.Printf("GETTING LOGGER FROM CONTEXT: %+v\n", ctx)
 	if ctx != nil {
 		if logger, ok := ctx.Value(loggerKey{}).(*zap.SugaredLogger); ok {
-			fmt.Printf("USING EXISTING LOGGER IN CONTEXT\n")
 			return logger
 		}
 	}
-	fmt.Printf("RETURNING FALLBACK LOGGER\n")
 	return fallbackLogger
 }
 

--- a/contextutils/context_and_logging.go
+++ b/contextutils/context_and_logging.go
@@ -19,6 +19,7 @@ package contextutils
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"go.uber.org/zap"
@@ -46,10 +47,13 @@ func buildProductionLogger() (*zap.Logger, error) {
 	config := zap.NewProductionConfig()
 	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 
-	// For non-splt logging, allow the user/environment to specify a log file location.
+	// For non-split logging, allow the user/environment to specify a log file location.
 	// When we log to a file, we will not log it STDOUT.
 	if os.Getenv(LogToFileLocationEnvName) != "" {
+		fmt.Printf("LOGGING TO FILE LOCATION: %s\n", os.Getenv(LogToFileLocationEnvName))
 		config.OutputPaths = []string{os.Getenv(LogToFileLocationEnvName)}
+	} else {
+		fmt.Printf("NOT LOGGING TO FILE LOCATION\n")
 	}
 
 	level = zap.NewAtomicLevel()

--- a/contextutils/context_and_logging.go
+++ b/contextutils/context_and_logging.go
@@ -50,10 +50,7 @@ func buildProductionLogger() (*zap.Logger, error) {
 	// For non-split logging, allow the user/environment to specify a log file location.
 	// When we log to a file, we will not log it STDOUT.
 	if os.Getenv(LogToFileLocationEnvName) != "" {
-		fmt.Printf("LOGGING TO FILE LOCATION: %s\n", os.Getenv(LogToFileLocationEnvName))
 		config.OutputPaths = []string{os.Getenv(LogToFileLocationEnvName)}
-	} else {
-		fmt.Printf("NOT LOGGING TO FILE LOCATION\n")
 	}
 
 	level = zap.NewAtomicLevel()
@@ -109,13 +106,11 @@ func init() {
 		buildLogger = buildSplitOutputProductionLogger
 	}
 	if logger, err := buildLogger(); err != nil {
-		fmt.Printf("ERROR BUILDING LOGGER: %v\n", err)
 
 		// We failed to create a fallback logger. Our fallback
 		// unfortunately falls back to noop.
 		fallbackLogger = zap.NewNop().Sugar()
 	} else {
-		fmt.Printf("SETTING FALLBACKLOGGER TO LOGGER FROM BUILDLOGGER()\n")
 		fallbackLogger = logger.Sugar()
 	}
 }
@@ -137,7 +132,6 @@ func BuildLoggerFromConfig(config zap.Config) (*zap.Logger, error) {
 }
 
 func SetFallbackLogger(logger *zap.SugaredLogger) {
-	fmt.Printf("IN SetFallbackLogger()\n")
 	fallbackLogger = logger
 }
 

--- a/contextutils/context_and_logging.go
+++ b/contextutils/context_and_logging.go
@@ -129,8 +129,10 @@ func BuildLoggerFromConfig(config zap.Config) (*zap.Logger, error) {
 		config.OutputPaths = []string{os.Getenv(LogToFileLocationEnvName)}
 	}
 
-	level = zap.NewAtomicLevel()
-	config.Level = level
+	if config.Level == (zap.AtomicLevel{}) {
+		level = zap.NewAtomicLevel()
+		config.Level = level
+	}
 	return config.Build()
 }
 

--- a/contextutils/context_and_logging.go
+++ b/contextutils/context_and_logging.go
@@ -120,6 +120,20 @@ func init() {
 	}
 }
 
+func BuildLoggerFromConfig(config zap.Config) (*zap.Logger, error) {
+	if config.EncoderConfig.EncodeTime == nil {
+		config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	}
+
+	if os.Getenv(LogToFileLocationEnvName) != "" {
+		config.OutputPaths = []string{os.Getenv(LogToFileLocationEnvName)}
+	}
+
+	level = zap.NewAtomicLevel()
+	config.Level = level
+	return config.Build()
+}
+
 func SetFallbackLogger(logger *zap.SugaredLogger) {
 	fmt.Printf("IN SetFallbackLogger()\n")
 	fallbackLogger = logger


### PR DESCRIPTION
Add `BuildLoggerFromConfig()` function that allows a caller to create a logger using a `zap.Config`

The key functionality this adds a way to create a new logger that respects the `LOG_TO_FILE_LOCATION` env var without the caller having to have knowledge of that env var

This is used in solo-io/dev-portal#2893 [here](https://github.com/solo-io/dev-portal/pull/2893/files#diff-f36fcc143c1388c7c89b28b165cfb74d7f4c00fd6e58667a5594437f13180436R83) to replace an instance where a new logger was previously created directly using the `zaputil.NewRaw()` function

An alternative would be to have consumers leverage the `LogToFileLocation` const to determine the output location, create a `zap.Config` and call `config.Build()` directly
Since this also requires callers to depend on `contextutils`, we may as well have the util library create the logger, handling logic for file location and default timestamp format
