### PR TITLE
Coerce LabelVersion to 1 for alpine labels

### DIFF
--- a/changelog/v0.27.1/fix-alpine-labeling.yaml
+++ b/changelog/v0.27.1/fix-alpine-labeling.yaml
@@ -2,3 +2,4 @@ changelog:
   - type: FIX
     description: >
       Fix a bug that results in duplicate versions in the output of the changeloggenutils GenerateJSON function when the label is "alpine"
+    issueLink: https://github.com/solo-io/go-utils/issues/537

--- a/changelog/v0.27.1/fix-alpine-labeling.yaml
+++ b/changelog/v0.27.1/fix-alpine-labeling.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: >
+      Fix a bug that results in duplicate versions in the output of the changeloggenutils GenerateJSON function when the label is "alpine"


### PR DESCRIPTION
The way this utility is generating the json for the changelog used by our documentation portal results in duplicate entries when the release label is "alpine". This PR sets the LabelVersion value to 1 when it detects a label of "alpine". This results in a unique version for the alpine build and the non-alpine build.

I'm open to other ways of solving this, but there cannot be duplicate version keys in the resulting json.

Before:

```json
        {
          "v1.16.11": {
            "Categories": {
              "Dependency Bumps": [
                {
                  "Note": "solo-io/gloo has been upgraded to v1.16.16."
                }
              ],
              "Fixes": [
                {
                  "Note": "Fix an issue where the wrong query param was discovered for a rest resolver. (https://github.com/solo-io/solo-projects/issues/6275)"
                },
                {
                  "Note": "Fixing MaxDepth not processed and propagated to envoy. (https://github.com/solo-io/solo-projects/issues/6372)"
                }
              ]
            },
            "ExtraNotes": null,
            "HeaderSuffix": " (Uses OSS [v1.16.16](https://github.com/solo-io/gloo/releases/tag/v1.16.16))",
            "CreatedAt": 1718805188
          }
        },
        {
          "v1.16.11": {
            "Categories": {
              "Fixes": [
                {
                  "Note": "Keep Alpine branch alive for some 1.16 branches (https://github.com/solo-io/gloo/issues/8849)"
                },
                {
                  "Note": "Adds the `host_rewrite_header` to the route options to allow envoy to swapped the host header with the content of given downstream or custom header. Pay attention to the potential security implications of using this option. Provided header must come from trusted source. (https://github.com/solo-io/gloo/issues/9579)",
                  "FromDependentVersion": "v1.16.16"
                },
                {
                  "Note": "Previously, header names consisting of invalid characters such as '()[]:;,\u003c=\u003e' were accepted when passed via the healthCheck or headerManipulation `requestHeadersToAdd` parameter. This resulted in envoy throwing an `invalid header name` error. Now, header names are validated according to RFC 9110, which is the same validation used by envoy. If a header name consisting of invalid characters is passed via the aforementioned parameters, it is caught and rejected in edge and does not propagate to envoy. (https://github.com/solo-io/gloo/issues/9622)",
                  "FromDependentVersion": "v1.16.16"
                }
              ]
            },
            "ExtraNotes": null,
            "HeaderSuffix": " (Uses OSS [v1.16.16](https://github.com/solo-io/gloo/releases/tag/v1.16.16))",
            "CreatedAt": 1718890534
          }
        },
```

After:

```json
        {
          "v1.16.11": {
            "Categories": {
              "Dependency Bumps": [
                {
                  "Note": "solo-io/gloo has been upgraded to v1.16.16."
                }
              ],
              "Fixes": [
                {
                  "Note": "Fix an issue where the wrong query param was discovered for a rest resolver. (https://github.com/solo-io/solo-projects/issues/6275)"
                },
                {
                  "Note": "Fixing MaxDepth not processed and propagated to envoy. (https://github.com/solo-io/solo-projects/issues/6372)"
                }
              ]
            },
            "ExtraNotes": null,
            "HeaderSuffix": " (Uses OSS [v1.16.16](https://github.com/solo-io/gloo/releases/tag/v1.16.16))",
            "CreatedAt": 1718805188
          }
        },
        {
          "v1.16.11-alpine1": {
            "Categories": {
              "Fixes": [
                {
                  "Note": "Keep Alpine branch alive for some 1.16 branches (https://github.com/solo-io/gloo/issues/8849)"
                },
                {
                  "Note": "Adds the `host_rewrite_header` to the route options to allow envoy to swapped the host header with the content of given downstream or custom header. Pay attention to the potential security implications of using this option. Provided header must come from trusted source. (https://github.com/solo-io/gloo/issues/9579)",
                  "FromDependentVersion": "v1.16.16"
                },
                {
                  "Note": "Previously, header names consisting of invalid characters such as '()[]:;,\u003c=\u003e' were accepted when passed via the healthCheck or headerManipulation `requestHeadersToAdd` parameter. This resulted in envoy throwing an `invalid header name` error. Now, header names are validated according to RFC 9110, which is the same validation used by envoy. If a header name consisting of invalid characters is passed via the aforementioned parameters, it is caught and rejected in edge and does not propagate to envoy. (https://github.com/solo-io/gloo/issues/9622)",
                  "FromDependentVersion": "v1.16.16"
                }
              ]
            },
            "ExtraNotes": null,
            "HeaderSuffix": " (Uses OSS [v1.16.16](https://github.com/solo-io/gloo/releases/tag/v1.16.16))",
            "CreatedAt": 1718890534
          }
        },

```
BOT NOTES: 
resolves https://github.com/solo-io/go-utils/issues/537