### PR TITLE
security-scan: conditionally allow scanning pre-release versions

### DIFF
--- a/changelog/v0.27.2/enable-pre-release-scan.yaml
+++ b/changelog/v0.27.2/enable-pre-release-scan.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      Enable security scans for pre-releases if --enable-pre-release=true.

--- a/securityscanutils/commands/format_results.go
+++ b/securityscanutils/commands/format_results.go
@@ -239,7 +239,7 @@ func readImageVersionConstraintsFile(opts *formatResultsOptions) (map[string][]s
 		if len(values) < 2 {
 			return nil, MalformedVersionImageConstraintLine(line)
 		}
-		for i, _ := range values {
+		for i := range values {
 			trimVal := strings.TrimSpace(values[i])
 			values[i] = trimVal
 			if i > 0 {
@@ -249,7 +249,7 @@ func readImageVersionConstraintsFile(opts *formatResultsOptions) (map[string][]s
 		imagesPerVersion[values[0]] = values[1:]
 	}
 	var allImages []string
-	for image, _ := range imageSet {
+	for image := range imageSet {
 		allImages = append(allImages, image)
 	}
 	opts.allImages = allImages

--- a/securityscanutils/commands/scan_repo.go
+++ b/securityscanutils/commands/scan_repo.go
@@ -49,6 +49,8 @@ type scanRepoOptions struct {
 	releaseVersionConstraint    string
 	imagesVersionConstraintFile string
 	additionalContextFile       string
+
+	enablePreRelease bool
 }
 
 func (m *scanRepoOptions) addToFlags(flags *pflag.FlagSet) {
@@ -58,6 +60,8 @@ func (m *scanRepoOptions) addToFlags(flags *pflag.FlagSet) {
 	flags.StringVarP(&m.vulnerabilityAction, "vulnerability-action", "a", "none", "action to take when a vulnerability is discovered {none, github-issue-all, github-issue-latest, output-locally}")
 
 	flags.StringVarP(&m.releaseVersionConstraint, "release-constraint", "c", "", "version constraint for releases to scan")
+	flags.BoolVar(&m.enablePreRelease, "enable-pre-release", false, "enable pre-release versions to be scanned")
+
 	flags.StringVarP(&m.imagesVersionConstraintFile, "image-constraint-file", "i", "", "name of file with mapping of version to images")
 	flags.StringVarP(&m.additionalContextFile, "additional-context-file", "d", "", "name of file with any additional context to add to the top of the generated vulnerability report")
 
@@ -94,6 +98,7 @@ func doScanRepo(ctx context.Context, opts *scanRepoOptions) error {
 					CreateGithubIssuePerVersion:            opts.vulnerabilityAction == "github-issue-all",
 					CreateGithubIssueForLatestPatchVersion: opts.vulnerabilityAction == "github-issue-latest",
 					AdditionalContext:                      additionalContext,
+					EnablePreRelease:                       opts.enablePreRelease,
 				},
 			},
 		},

--- a/securityscanutils/commands/utils.go
+++ b/securityscanutils/commands/utils.go
@@ -7,11 +7,9 @@ import (
 	"github.com/rotisserie/eris"
 )
 
-var (
-	MalformedVersionImageConstraintLine = func(line string) error {
-		return eris.Errorf("Could not properly split version image constraint line: %s", line)
-	}
-)
+var MalformedVersionImageConstraintLine = func(line string) error {
+	return eris.Errorf("Could not properly split version image constraint line: %s", line)
+}
 
 // GetImagesPerVersionFromFile Reads in a file, and tries to turn it into a map from version constraints to lists of images
 // As a byproduct, it also caches all unique images found into the option field 'allImages'
@@ -33,7 +31,7 @@ func GetImagesPerVersionFromFile(constraintsFile string) (map[string][]string, e
 		if len(values) < 2 {
 			return nil, MalformedVersionImageConstraintLine(line)
 		}
-		for i, _ := range values {
+		for i := range values {
 			trimVal := strings.TrimSpace(values[i])
 			values[i] = trimVal
 			if i > 0 {

--- a/securityscanutils/securityscan.go
+++ b/securityscanutils/securityscan.go
@@ -101,6 +101,9 @@ type SecurityScanOpts struct {
 	// Additional context to add to the top of the generated vulnerability report.
 	// Example: This could be used to provide debug instructions to developers.
 	AdditionalContext string
+
+	// Enable scanning of pre-release versions
+	EnablePreRelease bool
 }
 
 // GenerateSecurityScans generates .md files and writes them to the configured OutputDir for each repo
@@ -156,7 +159,8 @@ func (s *SecurityScanner) initializeRepoConfiguration(ctx context.Context, repo 
 	repoOptions := repo.Opts
 
 	// Set the Predicate used to filter releases we wish to scan
-	repo.scanReleasePredicate = NewSecurityScanRepositoryReleasePredicate(repoOptions.VersionConstraint)
+	repo.scanReleasePredicate = NewSecurityScanRepositoryReleasePredicate(
+		repoOptions.VersionConstraint, repoOptions.EnablePreRelease)
 
 	logger.Debugf("Scanning github repo for releases that match version constraint: %s", repoOptions.VersionConstraint)
 


### PR DESCRIPTION
Conditionally allows running image scans against Github releases marked as pre-release.

Testing done:
- Unit test

- Manual test
without `--enable-pre-release`
```
$ go run /src/code/go-utils/securityscanutils/cli scan-repo -v     -i /src/code/gloo-operator/docs/cmd/imageVersionConstraints.csv    -c ">=v0.1.0-0"         -r us-docker.pkg.dev/solo-public/gloo-operator  -g gloo-operator        -a output-locally          -d /src/code/gloo-operator/docs/cmd/securityScanDebugInstructions.md

{"level":"debug","ts":"2024-11-21T13:12:11.845-0800","caller":"securityscanutils/securityscan.go:176","msg":"Number of github releases to scan: 0"}
```

with `--enable-pre-release`
```
go run /src/code/go-utils/securityscanutils/cli scan-repo -v     -i /src/code/gloo-operator/docs/cmd/imageVersionConstraints.csv    -c ">=v0.1.0-0"         -r us-docker.pkg.dev/solo-public/gloo-operator  -g gloo-operator        -a output-locally          -d /src/code/gloo-operator/docs/cmd/securityScanDebugInstructions.md --enable-pre-release

{"level":"debug","ts":"2024-11-21T13:12:14.772-0800","caller":"securityscanutils/securityscan.go:176","msg":"Number of github releases to scan: 1"}
{"level":"debug","ts":"2024-11-21T13:12:14.772-0800","caller":"securityscanutils/securityscan.go:203","msg":"LocalIssueWriter configured with Predicate: &{}"}
{"level":"debug","ts":"2024-11-21T13:12:14.772-0800","caller":"securityscanutils/securityscan.go:211","msg":"Completed processing user defined configuration."}
{"level":"debug","ts":"2024-11-21T13:12:14.862-0800","caller":"securityscanutils/trivy_scanner.go:89","msg":"Trivy returned 0 after 90.231655ms on us-docker.pkg.dev/solo-public/gloo-operator/gloo-operator:0.1.0-alpha.0"}
{"level":"info","ts":"2024-11-21T13:12:14.863-0800","caller":"securityscanutils/securityscan.go:276","msg":"no vulnerabilities found for version 0.1.0-alpha.0 of gloo-operator repo, skipping issue write"}
```