### PR TITLE
Stepping over cache issue

### DIFF
--- a/changelog/v0.28.4/fixing-cache-issue.yaml
+++ b/changelog/v0.28.4/fixing-cache-issue.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: "Bumping version step over some Go cache issues"


### PR DESCRIPTION
I was seeing issues with mismatch checksums with v0.28.0. While debugging, I made tags and used them in another repo, likely tainting the sum cache. The other versions worked as expected. This PR steps over the likely tainted sums.