### PR TITLE
don't reset labels when updating gh issue for trivy scan

### DIFF
--- a/changelog/v0.28.5/update-gh-issue-writer.yaml
+++ b/changelog/v0.28.5/update-gh-issue-writer.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: |
+      Updated security scan GH issue writer to not purge existing labels.


### PR DESCRIPTION
When trivy scan runs and creates/updates GH issue it resets labels to ('trivy', 'vulnerability'). This leads to labels getting purged which gets added manually e.g 'Prioritized' label added by product

related issue : https://github.com/solo-io/gloo-mesh-enterprise/issues/20331

This PR updates security scan gh issue writer to merge labels instead of overriding them.

test GH issue : https://github.com/solo-io/gloo-mesh-enterprise/issues/20604
test run using this PR branch which respects existing labels
```
go get github.com/solo-io/go-utils@rav/gh-issue-writer-update

GOPRIVATE=github.com/solo-io GO111MODULE=on go run github.com/solo-io/go-utils/securityscanutils/cli scan-repo -v \
	-i ./docs/cmd/imageVersionConstraints.csv \
	-c "=v2.4.16" \
	-r gcr.io/gloo-mesh \
	-g gloo-mesh-enterprise \
	-a github-issue-latest \
	-d ./docs/cmd/securityScanDebugInstructions.md
{"level":"debug","ts":"2025-05-01T08:35:22.076-0700","caller":"securityscanutils/securityscan.go:151","msg":"Processing user defined configuration for repository (solo-io, gloo-mesh-enterprise)"}
{"level":"debug","ts":"2025-05-01T08:35:22.077-0700","caller":"securityscanutils/securityscan.go:165","msg":"Scanning github repo for releases that match version constraint: =v2.4.16"}
{"level":"debug","ts":"2025-05-01T08:35:24.036-0700","caller":"securityscanutils/securityscan.go:176","msg":"Number of github releases to scan: 1"}
{"level":"debug","ts":"2025-05-01T08:35:24.037-0700","caller":"securityscanutils/securityscan.go:197","msg":"GithubIssueWriter configured with Predicate: &{releasesByTagName:map[v2.4.16:0x14000299900]}"}
{"level":"debug","ts":"2025-05-01T08:35:24.037-0700","caller":"securityscanutils/securityscan.go:211","msg":"Completed processing user defined configuration."}
{"level":"debug","ts":"2025-05-01T08:35:29.858-0700","caller":"securityscanutils/trivy_scanner.go:83","msg":"Trivy found vulnerabilies after 5.821152666s in gcr.io/gloo-mesh/gloo-mesh-agent:2.4.16"}
{"level":"debug","ts":"2025-05-01T08:35:32.349-0700","caller":"securityscanutils/trivy_scanner.go:83","msg":"Trivy found vulnerabilies after 2.483018708s in gcr.io/gloo-mesh/gloo-mesh-apiserver:2.4.16"}
{"level":"debug","ts":"2025-05-01T08:35:35.015-0700","caller":"securityscanutils/trivy_scanner.go:89","msg":"Trivy returned 0 after 2.653368208s on gcr.io/gloo-mesh/gloo-mesh-envoy:2.4.16"}
{"level":"debug","ts":"2025-05-01T08:35:37.512-0700","caller":"securityscanutils/trivy_scanner.go:83","msg":"Trivy found vulnerabilies after 2.496536458s in gcr.io/gloo-mesh/gloo-mesh-istiod-agent:2.4.16"}
{"level":"debug","ts":"2025-05-01T08:35:40.009-0700","caller":"securityscanutils/trivy_scanner.go:83","msg":"Trivy found vulnerabilies after 2.48794875s in gcr.io/gloo-mesh/gloo-mesh-mgmt-server:2.4.16"}
{"level":"debug","ts":"2025-05-01T08:35:42.871-0700","caller":"securityscanutils/trivy_scanner.go:83","msg":"Trivy found vulnerabilies after 2.842674458s in gcr.io/gloo-mesh/gloo-mesh-portal-server:2.4.16"}
{"level":"debug","ts":"2025-05-01T08:35:45.520-0700","caller":"securityscanutils/trivy_scanner.go:83","msg":"Trivy found vulnerabilies after 2.638142s in gcr.io/gloo-mesh/gloo-mesh-spire-controller:2.4.16"}
{"level":"debug","ts":"2025-05-01T08:35:48.098-0700","caller":"securityscanutils/trivy_scanner.go:89","msg":"Trivy returned 0 after 2.568061167s on gcr.io/gloo-mesh/gloo-mesh-ui:2.4.16"}
{"level":"warn","ts":"2025-05-01T08:35:49.782-0700","caller":"securityscanutils/trivy_scanner.go:95","msg":"Trivy scan with args [[image --exit-code 52 --severity HIGH,CRITICAL --format template --template @/var/folders/6c/sz1cdxy148s7b0qxxtrd0z3c0000gn/T/2239521868 --output _output/scans/gloo-mesh-enterprise/markdown_results/2.4.16/gloo-otel-controller_cve_report.docgen gcr.io/gloo-mesh/gloo-otel-controller:2.4.16]] produced image not found error"}
{"level":"debug","ts":"2025-05-01T08:35:49.782-0700","caller":"issuewriter/github_writer.go:102","msg":"GithubIssueWriter attempting to create or update issue: Security Alert: 2.4.16"}
{"level":"debug","ts":"2025-05-01T08:35:51.054-0700","caller":"securityscanutils/securityscan.go:140","msg":"Completed running markdown scan for release v2.4.16 of gloo-mesh-enterprise repo after 27.017195792s"}
```