### PR TITLE
Update Go version to 1.24.6

### DIFF
--- a/changelog/v0.28.6/go-1-24-6.yaml
+++ b/changelog/v0.28.6/go-1-24-6.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: golang
+    dependencyRepo: go
+    dependencyTag: v1.24.6
+    description: "Update Go to 1.24.6" 

--- a/changelog/v0.28.6/go-1-24-6.yaml
+++ b/changelog/v0.28.6/go-1-24-6.yaml
@@ -3,4 +3,6 @@ changelog:
     dependencyOwner: golang
     dependencyRepo: go
     dependencyTag: v1.24.6
-    description: "Update Go to 1.24.6" 
+    description: "Update Go to 1.24.6"
+    issueLink: https://github.com/solo-io/solo-projects/issues/8512
+    resolvesIssue: false 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/solo-io/go-utils
 
-go 1.24
+go 1.24.6
 
 require (
 	cloud.google.com/go/pubsub v1.33.0


### PR DESCRIPTION
Update Go version to 1.24.6

snyk errors can be ignored as those scans are in the process of being implemented.