### PR TITLE
Fix Trivy template compatibility and bump Go to 1.26.5

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -30,12 +30,13 @@ jobs:
         service_account_key: ${{ secrets.GCP_SA_KEY }}
         export_default_credentials: true
       name: Gcloud Login
-    - name: Install Trivy (latest)
+    - name: Install Trivy
+      env:
+        TRIVY_VERSION: 0.72.0
       run: |
-          TRIVY_VERSION=$(curl --silent "https://api.github.com/repos/aquasecurity/trivy/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') 
-          echo Using Trivy v${TRIVY_VERSION}
-          wget https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.deb
-          sudo dpkg -i trivy_${TRIVY_VERSION}_Linux-64bit.deb
+          echo "Using Trivy v${TRIVY_VERSION}"
+          wget "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.deb"
+          sudo dpkg -i "trivy_${TRIVY_VERSION}_Linux-64bit.deb"
     - name: Set up Go
       uses: actions/setup-go@v4
       with:

--- a/changelog/v0.30.1/trivy-template-extension.yaml
+++ b/changelog/v0.30.1/trivy-template-extension.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Create Trivy templates with the required .tpl extension so security scans
+      remain compatible with Trivy v0.70.0 and later.
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: golang
+    dependencyRepo: go
+    dependencyTag: v1.26.5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/solo-io/go-utils
 
-go 1.26.1
+go 1.26.5
 
 require (
 	cloud.google.com/go/pubsub v1.33.0

--- a/securityscanutils/trivy_scanner_test.go
+++ b/securityscanutils/trivy_scanner_test.go
@@ -35,7 +35,9 @@ var _ = Describe("Trivy Scanner", func() {
 	})
 
 	JustAfterEach(func() {
-		err := os.RemoveAll(outputDir)
+		err := os.Remove(inputMarkdownTemplateFile)
+		Expect(err).NotTo(HaveOccurred())
+		err = os.RemoveAll(outputDir)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/securityscanutils/trivy_templates.go
+++ b/securityscanutils/trivy_templates.go
@@ -1,7 +1,7 @@
 package securityscanutils
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/rotisserie/eris"
 )
@@ -27,17 +27,22 @@ Vulnerability ID|Package|Severity|Installed Version|Fixed Version|Reference
 Trivy Returned Empty Report
 {{- end }}`
 
-// Create tempoarary file that contains the trivy template
-// Trivy CLI only accepts files as input for a template, so this is a workaround
+// Create temporary file that contains the trivy template.
+// Trivy requires custom template files to use the .tpl extension.
 func GetTemplateFile(trivyTemplate string) (string, error) {
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "trivy-*.tpl")
 	if err != nil {
 		return "", eris.Wrap(err, "Unable to create temporary file to write template to")
 	}
-	_, err = f.Write([]byte(trivyTemplate))
-	if err != nil {
+	templateFile := f.Name()
+	if _, err = f.WriteString(trivyTemplate); err != nil {
+		_ = f.Close()
+		_ = os.Remove(templateFile)
 		return "", eris.Wrapf(err, "Unable to write template to file %s", f.Name())
 	}
-	f.Close()
-	return f.Name(), nil
+	if err = f.Close(); err != nil {
+		_ = os.Remove(templateFile)
+		return "", eris.Wrapf(err, "Unable to close template file %s", templateFile)
+	}
+	return templateFile, nil
 }

--- a/securityscanutils/trivy_templates_test.go
+++ b/securityscanutils/trivy_templates_test.go
@@ -1,0 +1,23 @@
+package securityscanutils_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/solo-io/go-utils/securityscanutils"
+)
+
+var _ = Describe("Trivy Templates", func() {
+	It("creates a .tpl file containing the requested template", func() {
+		templateFile, err := GetTemplateFile(MarkdownTrivyTemplate)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(os.Remove, templateFile)
+
+		Expect(filepath.Ext(templateFile)).To(Equal(".tpl"))
+		contents, err := os.ReadFile(templateFile)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(contents)).To(Equal(MarkdownTrivyTemplate))
+	})
+})


### PR DESCRIPTION
## Summary

- Create temporary Trivy templates with the required `.tpl` extension.
- Clean up temporary files when writing or closing them fails.
- Add regression coverage for the template filename and contents.
- Clean up temporary templates created by the scanner tests.
- Pin PR integration tests to Trivy v0.72.0 instead of dynamically installing the latest release.
- Bump Go from 1.26.1 to 1.26.5.

## Root cause

Trivy v0.70.0 began requiring custom template filenames to end in `.tpl`. `GetTemplateFile` created an extensionless temporary file, causing scans with newer Trivy versions to fail before scanning any images.

The scanner retried the invalid invocation and eventually returned an `Unrecoverable` error, preventing downstream security-alert issues from being created or updated.

## Validation

- Ran `go mod verify`.
- Ran `go test ./securityscanutils`.
- Confirmed the tests use Go 1.26.5.
- Validated the new changelog entry.
- Ran `git diff --check`.

## Follow-up

Consumers should upgrade to the resulting `go-utils` release before updating their pinned Trivy version to v0.70.0 or later.